### PR TITLE
feat(subagents): add optional directory parameter to delegate_subagent_task

### DIFF
--- a/src/assistant/agent/tools/delegate_subagent_task.py
+++ b/src/assistant/agent/tools/delegate_subagent_task.py
@@ -18,6 +18,7 @@ async def delegate_subagent_task(
     ctx: RunContext[TurnDeps],
     objective: str,
     model_id: str | None = None,
+    directory: str | None = None,
 ) -> dict[str, Any]:
     """Create a delegated background task and return immediate acknowledgement."""
     handler = ctx.deps.delegation_enqueue_handler
@@ -27,10 +28,14 @@ async def delegate_subagent_task(
             "status": "unavailable",
             "rejection_reason": "delegation disabled",
         }
+    backend_params: dict[str, Any] = {}
+    if directory:
+        backend_params["directory"] = directory
     request: dict[str, Any] = {
         "objective": objective,
         "model_id": model_id,
         "tool_params": ctx.deps.tool_runtime_params.get("delegate_subagent_task", {}),
+        "backend_params": backend_params,
     }
     result = await handler(request)
     logger.info(

--- a/src/assistant/subagents/backends/claude_code.py
+++ b/src/assistant/subagents/backends/claude_code.py
@@ -25,11 +25,13 @@ class ClaudeCodeBackendAdapter(DelegationBackendAdapterInterface):
     async def execute(self, request: DelegationRun) -> DelegationResult:
         prompt = self._build_prompt(request)
         cmd = self._build_command(request, prompt)
+        cwd = request.backend_params.get("directory") or None
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
             )
             stdout_b, stderr_b = await asyncio.wait_for(
                 process.communicate(),
@@ -76,4 +78,3 @@ class ClaudeCodeBackendAdapter(DelegationBackendAdapterInterface):
     @staticmethod
     def _build_prompt(request: DelegationRun) -> str:
         return f"Task objective:\n{request.objective}"
-


### PR DESCRIPTION
## Summary

- Adds optional `directory: str | None` parameter to `delegate_subagent_task` tool
- When provided, the value is forwarded through `backend_params["directory"]` to the Claude Code backend
- Backend passes it as `cwd` to `asyncio.create_subprocess_exec`, so the sub-agent runs in the specified directory
- Fully backward-compatible: omitting `directory` leaves behavior unchanged (inherits current process cwd)

## Test plan

- Existing unit tests in `tests/assistant/agent/tools/test_delegate_subagent_task.py` pass
- Manual: delegate a task with `directory="/some/repo"` and verify the sub-agent operates in that directory

Generated with Claude Code
