### PR TITLE
fix(agent): fall back to intermediate text when final response is empty

### DIFF
--- a/src/assistant/agent/pydantic_ai_agent.py
+++ b/src/assistant/agent/pydantic_ai_agent.py
@@ -13,6 +13,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    TextPart,
     ToolCallPart,
     ToolReturnPart,
 )
@@ -185,6 +186,20 @@ class PydanticAITurnAdapter:
             return "", [], None
         response_text = result.output
         new_msgs = result.new_messages()
+
+        # Fallback: if the final output is empty, the model may have returned explanatory
+        # text in a mixed ModelResponse (TextPart + ToolCallPart) that pydantic_ai treats
+        # as an intermediate step and therefore excludes from result.output.  Scan the new
+        # messages in reverse and use the last such intermediate text so the user receives
+        # a response rather than silence.
+        if not response_text:
+            for msg in reversed(list(new_msgs)):
+                if isinstance(msg, ModelResponse):
+                    text_parts = [p for p in msg.parts if isinstance(p, TextPart) and p.content]
+                    tool_parts = [p for p in msg.parts if isinstance(p, ToolCallPart)]
+                    if text_parts and tool_parts:
+                        response_text = " ".join(p.content for p in text_parts).strip()
+                        break
         usage = None
         usage_obj = result.usage()
         if usage_obj is not None:


### PR DESCRIPTION
Fixes #4

## Summary

- The Anthropic Claude API can return a `ModelResponse` containing both `TextPart` and `ToolCallPart` simultaneously. pydantic_ai treats such a response as an intermediate step and its text is excluded from `result.output`.
- When the model's final post-tool response contains no text, `result.output` is `""`, resulting in an empty `ChannelResponse` that Telegram rejects with a 400 error — and the user receives nothing.
- Added a fallback in `PydanticAITurnAdapter.run_turn()`: after extracting `result.output`, if it is empty, scan `new_messages()` in reverse for the most recent `ModelResponse` that contained both `TextPart`s and `ToolCallPart`s, and use its text as `response_text`.

## Changes

- `src/assistant/agent/pydantic_ai_agent.py`: import `TextPart`; add fallback extraction of intermediate text when `result.output` is empty.

## Test plan

- Reproduce the scenario: trigger a turn where the model returns text alongside a tool call and produces no additional text after the tool completes — verify the intermediate text is now delivered to Telegram.
- Verify normal turns (model returns text only in the final response) are unaffected.
- Verify turns where both intermediate and final text exist still deliver the final text (fallback only activates when `result.output` is empty).

Generated with Claude Code
