### PR TITLE
fix: prevent token leakage from unbounded tool outputs

### DIFF
--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -39,6 +39,7 @@ tools:
     entrypoint: assistant.agent.tools.shell_execute:shell_execute_readonly
     enabled: true
     default_params:
+      shell_max_output_chars: 8000
       shell_readonly_commands:
         - cat
         - date
@@ -59,6 +60,7 @@ tools:
     entrypoint: assistant.agent.tools.shell_execute:shell_execute_allowlisted
     enabled: true
     default_params:
+      shell_max_output_chars: 8000
       command_allowlist: []
 
   - tool_id: web_search

--- a/src/assistant/agent/pydantic_ai_agent.py
+++ b/src/assistant/agent/pydantic_ai_agent.py
@@ -152,7 +152,11 @@ class PydanticAITurnAdapter:
         user_prompt = _message_to_user_prompt_content(messages[-1])
         history_msgs = messages[:-1] if len(messages) > 1 else []
         history = _llm_messages_to_history(history_msgs)
-        model_settings = {"max_tokens": self._max_tokens}
+        model_settings: dict[str, Any] = {
+            "max_tokens": self._max_tokens,
+            "anthropic_cache_instructions": True,
+            "anthropic_cache_tool_definitions": True,
+        }
         async with self._agent.iter(  # type: ignore[call-overload]
             user_prompt,
             message_history=history,

--- a/src/assistant/agent/tools/shell_execute.py
+++ b/src/assistant/agent/tools/shell_execute.py
@@ -20,6 +20,7 @@ from assistant.core.config.schemas import CommandAllowlistEntry
 logger = structlog.get_logger(__name__)
 
 _MAX_TIMEOUT_SECONDS = 30
+_DEFAULT_MAX_OUTPUT_CHARS = 8_000
 
 
 def _get_tool_params(deps: TurnDeps, tool_id: str) -> dict[str, Any]:
@@ -38,6 +39,15 @@ def _normalize_allowlist(
         elif isinstance(item, dict):
             result.append(CommandAllowlistEntry(**item))
     return result
+
+
+def _truncate_output(text: str, max_chars: int) -> str:
+    """Truncate command output to max_chars, appending a notice if cut."""
+    if len(text) <= max_chars:
+        return text
+    kept = text[:max_chars]
+    omitted = len(text) - max_chars
+    return kept + f"\n... [truncated — {omitted} chars omitted]"
 
 
 def _parse_command(command: str) -> tuple[str, list[str]]:
@@ -61,6 +71,7 @@ def shell_execute_readonly(
     Allowed commands come from tool_runtime_params.
     """
     params = _get_tool_params(ctx.deps, "shell_execute_readonly")
+    max_output_chars: int = int(params.get("shell_max_output_chars") or _DEFAULT_MAX_OUTPUT_CHARS)
     readonly_commands = params.get("shell_readonly_commands") or []
     allowed_set = frozenset(
         c.strip().lower() for c in readonly_commands if isinstance(c, str) and c.strip()
@@ -121,8 +132,8 @@ def shell_execute_readonly(
         return {
             "status": "ok",
             "returncode": result.returncode,
-            "stdout": result.stdout or "",
-            "stderr": result.stderr or "",
+            "stdout": _truncate_output(result.stdout or "", max_output_chars),
+            "stderr": _truncate_output(result.stderr or "", max_output_chars),
         }
     except subprocess.TimeoutExpired:
         logger.warning(
@@ -178,6 +189,7 @@ def shell_execute_allowlisted(
     max_timeout_seconds cap.
     """
     params = _get_tool_params(ctx.deps, "shell_execute_allowlisted")
+    max_output_chars: int = int(params.get("shell_max_output_chars") or _DEFAULT_MAX_OUTPUT_CHARS)
     allowlist = _normalize_allowlist(params.get("command_allowlist") or [])
     if not allowlist:
         logger.info(
@@ -234,8 +246,8 @@ def shell_execute_allowlisted(
         return {
             "status": "ok",
             "returncode": result.returncode,
-            "stdout": result.stdout or "",
-            "stderr": result.stderr or "",
+            "stdout": _truncate_output(result.stdout or "", max_output_chars),
+            "stderr": _truncate_output(result.stderr or "", max_output_chars),
         }
     except subprocess.TimeoutExpired:
         logger.warning(

--- a/src/assistant/agent/tools/tavily_search.py
+++ b/src/assistant/agent/tools/tavily_search.py
@@ -25,6 +25,30 @@ from tavily.errors import (
     TimeoutError as TavilyTimeoutError,
 )
 
+_MAX_CONTENT_CHARS = 2_000
+_BINARY_THRESHOLD = 0.1  # fraction of non-printable chars that marks content as binary
+
+
+def _is_binary(text: str, sample: int = 500) -> bool:
+    """Return True if the text looks like binary data (e.g. raw XLS/PDF bytes)."""
+    chunk = text[:sample]
+    if not chunk:
+        return False
+    non_printable = sum(1 for c in chunk if ord(c) > 126 or (ord(c) < 32 and c not in "\t\n\r"))
+    return (non_printable / len(chunk)) > _BINARY_THRESHOLD
+
+
+def _sanitize_result(result: TavilySearchResult) -> TavilySearchResult:
+    """Truncate or replace content to prevent binary/oversized payloads inflating context."""
+    content: str = result.get("content") or ""  # type: ignore[union-attr]
+    if _is_binary(content):
+        content = "[binary content omitted]"
+    elif len(content) > _MAX_CONTENT_CHARS:
+        content = content[:_MAX_CONTENT_CHARS] + f"... [{len(content) - _MAX_CONTENT_CHARS} chars omitted]"
+    else:
+        return result
+    return {**result, "content": content}  # type: ignore[return-value]
+
 
 def get_tavily_search_tool() -> Any | None:
     """Return Tavily search tool if TAVILY_API_KEY is set, else None."""
@@ -44,7 +68,7 @@ def get_tavily_search_tool() -> Any | None:
     ) -> list[TavilySearchResult]:
         """Searches Tavily for the given query and returns the results."""
         try:
-            return await inner(
+            results = await inner(
                 query,
                 search_depth=search_depth,
                 topic=topic,
@@ -52,6 +76,7 @@ def get_tavily_search_tool() -> Any | None:
                 include_domains=include_domains,
                 exclude_domains=exclude_domains,
             )
+            return [_sanitize_result(r) for r in results]
         except BadRequestError as exc:
             raise ModelRetry(
                 "Tavily rejected the search query: "


### PR DESCRIPTION
## Summary

- **Shell output truncation** — `shell_execute_readonly` and `shell_execute_allowlisted` now cap `stdout`/`stderr` at 8K chars each (configurable via `shell_max_output_chars` in tool params). A single `find /project -name "*.py"` call was returning 10K file paths (~475K tokens), inflating every subsequent LLM call in the session.
- **Tavily binary/oversize filtering** — search results are sanitised before being returned to the agent: binary content (raw XLS/PDF bytes) is replaced with `[binary content omitted]`; clean content is capped at 2K chars per result.
- **Prompt caching** — `anthropic_cache_instructions` and `anthropic_cache_tool_definitions` are now enabled on every turn, caching the system prompt and tool definitions across calls (~80% cost reduction on those portions).

## Context

Diagnosed from Logfire traces for 2026-03-21, which showed $20.24 spend (48% of the monthly total) in a single day. Root cause: one session accumulated 3M+ input tokens after a `find` command flooded the context, and no prompt caching was active to offset repeat costs.

## Test plan

- [ ] `shell_execute_readonly` with a large-output command (e.g. `find / -name "*.py"`) returns truncated stdout with `[truncated — N chars omitted]` notice
- [ ] `shell_execute_allowlisted` same behaviour
- [ ] `shell_max_output_chars` override in capability config is respected
- [ ] Tavily result with binary content returns `[binary content omitted]`
- [ ] Tavily result with >2K chars of clean content is truncated with `[N chars omitted]`
- [ ] Logfire spans for new sessions show non-null `cache_read` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)