### PR TITLE
feat(mini-apps): Flashcards Telegram Mini App

### DIFF
--- a/mini-apps/flashcards/css/style.css
+++ b/mini-apps/flashcards/css/style.css
@@ -1,0 +1,454 @@
+/* ============================================================
+   Telegram theme CSS variables with browser fallbacks
+   ============================================================ */
+:root {
+  --tg-theme-bg-color: #ffffff;
+  --tg-theme-text-color: #000000;
+  --tg-theme-hint-color: #999999;
+  --tg-theme-link-color: #2481cc;
+  --tg-theme-button-color: #2481cc;
+  --tg-theme-button-text-color: #ffffff;
+  --tg-theme-secondary-bg-color: #f5f5f5;
+}
+
+/* ============================================================
+   Reset & base
+   ============================================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               Helvetica, Arial, sans-serif;
+  background-color: var(--tg-theme-bg-color);
+  color: var(--tg-theme-text-color);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* ============================================================
+   Screens
+   ============================================================ */
+.screen {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.screen-active {
+  display: flex;
+}
+
+/* ============================================================
+   Loading screen
+   ============================================================ */
+#screen-loading {
+  justify-content: center;
+}
+
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.loading-text {
+  color: var(--tg-theme-hint-color);
+  font-size: 1rem;
+}
+
+/* Spinner */
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--tg-theme-secondary-bg-color);
+  border-top-color: var(--tg-theme-button-color);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Error state inside loading screen */
+.error-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+}
+
+.error-icon {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.error-message {
+  font-size: 1rem;
+  color: var(--tg-theme-text-color);
+  max-width: 320px;
+}
+
+/* Warning banner for browser mode */
+.browser-warning {
+  background: #fff3cd;
+  color: #856404;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  text-align: center;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+}
+
+/* ============================================================
+   Exercise screen
+   ============================================================ */
+#screen-exercise {
+  padding-top: 0;
+  gap: 0;
+}
+
+/* Progress bar */
+#progress-bar-wrap {
+  width: 100%;
+  height: 4px;
+  background: var(--tg-theme-secondary-bg-color);
+  flex-shrink: 0;
+}
+
+#progress-bar {
+  height: 100%;
+  background: var(--tg-theme-button-color);
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+/* Card counter */
+.card-counter {
+  width: 100%;
+  max-width: 480px;
+  padding: 10px 20px 0;
+  text-align: right;
+  font-size: 0.85rem;
+  color: var(--tg-theme-hint-color);
+  flex-shrink: 0;
+}
+
+/* Card scene (3-D perspective wrapper) */
+.card-scene {
+  width: 100%;
+  max-width: 480px;
+  padding: 12px 20px;
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  perspective: 1000px;
+}
+
+/* Card itself */
+.card {
+  width: 100%;
+  min-height: 260px;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.45s ease;
+  cursor: pointer;
+}
+
+.card.flipped {
+  transform: rotateY(180deg);
+}
+
+/* Card faces */
+.card-face {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  min-height: 260px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  background: var(--tg-theme-secondary-bg-color);
+  border-radius: 16px;
+  padding: 28px 24px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.card-back {
+  transform: rotateY(180deg);
+  justify-content: flex-start;
+  padding-top: 24px;
+}
+
+/* ---- Card typography ---- */
+
+/* Primary word (big Greek or big Russian) */
+.word-primary {
+  font-size: 2.5rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.2;
+  color: var(--tg-theme-text-color);
+  word-break: break-word;
+}
+
+/* Transliteration */
+.word-transliteration {
+  font-size: 1.1rem;
+  color: var(--tg-theme-hint-color);
+  font-style: italic;
+  text-align: center;
+}
+
+/* Translation (big on back) */
+.word-translation {
+  font-size: 2rem;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.25;
+  color: var(--tg-theme-text-color);
+  word-break: break-word;
+}
+
+/* Small label shown at top of back side */
+.back-top-label {
+  font-size: 1rem;
+  color: var(--tg-theme-hint-color);
+  text-align: center;
+  width: 100%;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(128,128,128,0.15);
+  margin-bottom: 4px;
+}
+
+/* Verb forms table */
+.verb-forms {
+  width: 100%;
+  margin-top: 12px;
+  border-top: 1px solid rgba(128,128,128,0.15);
+  padding-top: 12px;
+}
+
+.verb-forms-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tg-theme-hint-color);
+  margin-bottom: 8px;
+}
+
+.verb-form-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.verb-form-label {
+  font-size: 0.82rem;
+  color: var(--tg-theme-hint-color);
+  white-space: nowrap;
+  min-width: 80px;
+}
+
+.verb-form-value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--tg-theme-text-color);
+  text-align: right;
+}
+
+.verb-form-trans {
+  font-size: 0.82rem;
+  color: var(--tg-theme-hint-color);
+  font-style: italic;
+  text-align: right;
+}
+
+/* Example sentence */
+.example-block {
+  width: 100%;
+  margin-top: 12px;
+  border-top: 1px solid rgba(128,128,128,0.15);
+  padding-top: 12px;
+}
+
+.example-greek {
+  font-size: 0.92rem;
+  color: var(--tg-theme-text-color);
+  margin-bottom: 4px;
+  font-style: italic;
+}
+
+.example-russian {
+  font-size: 0.88rem;
+  color: var(--tg-theme-hint-color);
+  font-style: italic;
+}
+
+/* ============================================================
+   Show answer button
+   ============================================================ */
+.btn-show-answer-wrap {
+  width: 100%;
+  max-width: 480px;
+  padding: 0 20px 16px;
+  flex-shrink: 0;
+}
+
+.btn-show-answer {
+  width: 100%;
+  min-height: 48px;
+  background: var(--tg-theme-button-color);
+  color: var(--tg-theme-button-text-color);
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn-show-answer:active {
+  opacity: 0.8;
+}
+
+/* ============================================================
+   Rating buttons
+   ============================================================ */
+.rating-buttons {
+  width: 100%;
+  max-width: 480px;
+  padding: 0 20px 20px;
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.rating-buttons.hidden {
+  display: none;
+}
+
+.btn-rating {
+  flex: 1;
+  min-height: 48px;
+  border: none;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+}
+
+.btn-rating:active {
+  opacity: 0.85;
+  transform: scale(0.97);
+}
+
+.btn-again { background: #ff4444; }
+.btn-hard  { background: #ff8c00; }
+.btn-good  { background: #4a90d9; }
+.btn-easy  { background: #27ae60; }
+
+/* ============================================================
+   Results screen
+   ============================================================ */
+#screen-results {
+  justify-content: center;
+  padding: 24px 20px 80px;  /* bottom padding for MainButton */
+}
+
+.results-content {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.results-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--tg-theme-text-color);
+}
+
+.results-breakdown {
+  width: 100%;
+  background: var(--tg-theme-secondary-bg-color);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.results-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+}
+
+.results-row-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--tg-theme-text-color);
+}
+
+.results-row-count {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--tg-theme-text-color);
+}
+
+.results-avg-time {
+  font-size: 0.95rem;
+  color: var(--tg-theme-hint-color);
+  text-align: center;
+}
+
+/* ============================================================
+   Utility
+   ============================================================ */
+.hidden {
+  display: none !important;
+}
+
+.w-full {
+  width: 100%;
+}

--- a/mini-apps/flashcards/index.html
+++ b/mini-apps/flashcards/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Flashcards</title>
+
+  <!-- Telegram WebApp SDK -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+
+  <!-- pako.js for gzip decompression -->
+  <script src="https://cdn.jsdelivr.net/npm/pako@2/dist/pako.min.js"></script>
+
+  <!-- App styles -->
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+
+  <!-- Loading / error screen -->
+  <div id="screen-loading" class="screen screen-active">
+    <div class="loading-content">
+      <div class="spinner"></div>
+      <p class="loading-text">Загрузка...</p>
+    </div>
+  </div>
+
+  <!-- Exercise screen -->
+  <div id="screen-exercise" class="screen">
+    <!-- Progress bar -->
+    <div id="progress-bar-wrap">
+      <div id="progress-bar"></div>
+    </div>
+
+    <!-- Card counter -->
+    <div id="card-counter" class="card-counter"></div>
+
+    <!-- Card container (flip wrapper) -->
+    <div id="card-scene" class="card-scene">
+      <div id="card" class="card">
+        <div class="card-face card-front" id="card-front"></div>
+        <div class="card-face card-back" id="card-back"></div>
+      </div>
+    </div>
+
+    <!-- Show answer button (visible on question side) -->
+    <div id="btn-show-answer-wrap" class="btn-show-answer-wrap">
+      <button id="btn-show-answer" class="btn-show-answer">Показать ответ</button>
+    </div>
+
+    <!-- Rating buttons (visible on answer side) -->
+    <div id="rating-buttons" class="rating-buttons hidden">
+      <button class="btn-rating btn-again"  data-rating="0">Again</button>
+      <button class="btn-rating btn-hard"   data-rating="1">Hard</button>
+      <button class="btn-rating btn-good"   data-rating="2">Good</button>
+      <button class="btn-rating btn-easy"   data-rating="3">Easy</button>
+    </div>
+  </div>
+
+  <!-- Results screen -->
+  <div id="screen-results" class="screen">
+    <div class="results-content">
+      <div class="results-title" id="results-title"></div>
+      <div class="results-breakdown" id="results-breakdown"></div>
+      <div class="results-avg-time" id="results-avg-time"></div>
+    </div>
+  </div>
+
+  <!-- App modules -->
+  <script src="js/decoder.js"></script>
+  <script src="js/cards.js"></script>
+  <script src="js/results.js"></script>
+  <script src="js/app.js"></script>
+
+</body>
+</html>

--- a/mini-apps/flashcards/index.html
+++ b/mini-apps/flashcards/index.html
@@ -49,10 +49,10 @@
 
     <!-- Rating buttons (visible on answer side) -->
     <div id="rating-buttons" class="rating-buttons hidden">
-      <button class="btn-rating btn-again"  data-rating="0">Again</button>
-      <button class="btn-rating btn-hard"   data-rating="1">Hard</button>
-      <button class="btn-rating btn-good"   data-rating="2">Good</button>
-      <button class="btn-rating btn-easy"   data-rating="3">Easy</button>
+      <button class="btn-rating btn-again"  data-rating="0">Снова</button>
+      <button class="btn-rating btn-hard"   data-rating="1">Трудно</button>
+      <button class="btn-rating btn-good"   data-rating="2">Хорошо</button>
+      <button class="btn-rating btn-easy"   data-rating="3">Легко</button>
     </div>
   </div>
 

--- a/mini-apps/flashcards/js/app.js
+++ b/mini-apps/flashcards/js/app.js
@@ -1,0 +1,133 @@
+/**
+ * app.js
+ * Main entry point for the Flashcards Mini App.
+ *
+ * Flow:
+ *   1. Init Telegram WebApp (or warn if running in browser)
+ *   2. Show loading screen
+ *   3. Parse URL params: `words` (required) and `dir` (optional, default 'forward')
+ *   4. Decode `words` payload with decodeWords()
+ *   5. Start card exercise via initCards()
+ *   6. On completion, show results via showResults()
+ */
+
+(function () {
+  // ── Telegram WebApp bootstrap ────────────────────────────────────────
+  const tg = window.Telegram && window.Telegram.WebApp;
+
+  if (tg) {
+    tg.ready();
+    tg.expand();
+
+    // Apply Telegram theme params as CSS custom properties
+    applyTheme(tg.themeParams);
+
+    // Keep CSS in sync if the theme changes
+    tg.onEvent('themeChanged', function () {
+      applyTheme(tg.themeParams);
+    });
+  } else {
+    // Opened outside Telegram — show a warning banner but keep working
+    showBrowserWarning();
+  }
+
+  // ── DOM refs ──────────────────────────────────────────────────────────
+  const screenLoading  = document.getElementById('screen-loading');
+  const screenExercise = document.getElementById('screen-exercise');
+
+  // ── Parse URL parameters ──────────────────────────────────────────────
+  const params    = new URLSearchParams(window.location.search);
+  const wordsParam = params.get('words');
+  const dirParam   = params.get('dir') || 'forward';
+
+  // Validate direction
+  const direction = (dirParam === 'reverse') ? 'reverse' : 'forward';
+
+  // ── Guard: missing `words` param ──────────────────────────────────────
+  if (!wordsParam) {
+    showError('Данные упражнения не найдены');
+    return;
+  }
+
+  // ── Decode payload ────────────────────────────────────────────────────
+  let words;
+  try {
+    words = decodeWords(wordsParam);
+  } catch (e) {
+    console.error('Decode error:', e);
+    showError('Ошибка декодирования данных');
+    return;
+  }
+
+  // ── Guard: empty word list ────────────────────────────────────────────
+  if (!Array.isArray(words) || words.length === 0) {
+    showError('Нет слов для изучения');
+    return;
+  }
+
+  // ── Start exercise ────────────────────────────────────────────────────
+  screenLoading.classList.remove('screen-active');
+  screenExercise.classList.add('screen-active');
+
+  initCards(words, direction, function (results) {
+    showResults(results, words.length);
+  });
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  /**
+   * Apply Telegram theme params as CSS variables on :root.
+   * @param {Object} params - Telegram.WebApp.themeParams
+   */
+  function applyTheme(params) {
+    if (!params) return;
+    const map = {
+      bg_color:            '--tg-theme-bg-color',
+      text_color:          '--tg-theme-text-color',
+      hint_color:          '--tg-theme-hint-color',
+      link_color:          '--tg-theme-link-color',
+      button_color:        '--tg-theme-button-color',
+      button_text_color:   '--tg-theme-button-text-color',
+      secondary_bg_color:  '--tg-theme-secondary-bg-color',
+    };
+    Object.keys(map).forEach(function (key) {
+      if (params[key]) {
+        document.documentElement.style.setProperty(map[key], params[key]);
+      }
+    });
+  }
+
+  /**
+   * Replace loading screen content with an error message.
+   * @param {string} message
+   */
+  function showError(message) {
+    screenLoading.classList.add('screen-active');
+    screenLoading.innerHTML =
+      '<div class="error-content">' +
+        '<div class="error-icon">⚠️</div>' +
+        '<div class="error-message">' + escapeHtml(message) + '</div>' +
+      '</div>';
+  }
+
+  /**
+   * Show a non-blocking warning banner when running in a browser.
+   */
+  function showBrowserWarning() {
+    const banner = document.createElement('div');
+    banner.className = 'browser-warning';
+    banner.textContent =
+      '⚠️ Приложение открыто вне Telegram. Отправка результатов недоступна.';
+    document.body.prepend(banner);
+  }
+
+  /**
+   * Minimal HTML escaping to prevent XSS in error messages.
+   */
+  function escapeHtml(str) {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+})();

--- a/mini-apps/flashcards/js/app.js
+++ b/mini-apps/flashcards/js/app.js
@@ -77,10 +77,10 @@
 
   /**
    * Apply Telegram theme params as CSS variables on :root.
-   * @param {Object} params - Telegram.WebApp.themeParams
+   * @param {Object} themeParams - Telegram.WebApp.themeParams
    */
-  function applyTheme(params) {
-    if (!params) return;
+  function applyTheme(themeParams) {
+    if (!themeParams) return;
     const map = {
       bg_color:            '--tg-theme-bg-color',
       text_color:          '--tg-theme-text-color',
@@ -91,8 +91,8 @@
       secondary_bg_color:  '--tg-theme-secondary-bg-color',
     };
     Object.keys(map).forEach(function (key) {
-      if (params[key]) {
-        document.documentElement.style.setProperty(map[key], params[key]);
+      if (themeParams[key]) {
+        document.documentElement.style.setProperty(map[key], themeParams[key]);
       }
     });
   }

--- a/mini-apps/flashcards/js/cards.js
+++ b/mini-apps/flashcards/js/cards.js
@@ -28,9 +28,12 @@
   let cardStartTime = 0;
   let onComplete  = null;
   let revealed    = false;
+  let initialized = false;
 
   // ── Init ──────────────────────────────────────────────────────────────
   function initCards(wordList, dir, completeCb) {
+    if (initialized) return;
+    initialized = true;
     words      = wordList;
     direction  = dir || 'forward';
     onComplete = completeCb;

--- a/mini-apps/flashcards/js/cards.js
+++ b/mini-apps/flashcards/js/cards.js
@@ -1,0 +1,234 @@
+/**
+ * cards.js
+ * Card state machine: renders question/answer sides and collects ratings.
+ *
+ * Public API:
+ *   initCards(words, direction, onComplete)
+ *   - words:       Array of CompactWordPayload
+ *   - direction:   'forward' | 'reverse'
+ *   - onComplete:  function(results) called when all cards are rated
+ */
+
+(function () {
+  // ── DOM refs ──────────────────────────────────────────────────────────
+  const cardEl         = document.getElementById('card');
+  const cardFront      = document.getElementById('card-front');
+  const cardBack       = document.getElementById('card-back');
+  const counterEl      = document.getElementById('card-counter');
+  const progressBar    = document.getElementById('progress-bar');
+  const btnShowAnswer  = document.getElementById('btn-show-answer');
+  const btnShowWrap    = document.getElementById('btn-show-answer-wrap');
+  const ratingButtons  = document.getElementById('rating-buttons');
+
+  // ── State ─────────────────────────────────────────────────────────────
+  let words       = [];
+  let direction   = 'forward';
+  let currentIdx  = 0;
+  let results     = [];
+  let cardStartTime = 0;
+  let onComplete  = null;
+  let revealed    = false;
+
+  // ── Init ──────────────────────────────────────────────────────────────
+  function initCards(wordList, dir, completeCb) {
+    words      = wordList;
+    direction  = dir || 'forward';
+    onComplete = completeCb;
+    currentIdx = 0;
+    results    = [];
+    revealed   = false;
+
+    // Attach rating button listeners once
+    ratingButtons.querySelectorAll('.btn-rating').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        if (!revealed) return;
+        const rating = parseInt(btn.getAttribute('data-rating'), 10);
+        handleRating(rating);
+      });
+    });
+
+    // "Show answer" button + card tap both reveal
+    btnShowAnswer.addEventListener('click', revealAnswer);
+    cardEl.addEventListener('click', function () {
+      if (!revealed) revealAnswer();
+    });
+
+    showQuestion(currentIdx);
+  }
+
+  // ── Question side ─────────────────────────────────────────────────────
+  function showQuestion(idx) {
+    revealed = false;
+
+    const word = words[idx];
+    updateProgress(idx);
+    updateCounter(idx);
+
+    // Remove flip so front is visible
+    cardEl.classList.remove('flipped');
+
+    // Build front face content
+    cardFront.innerHTML = '';
+
+    if (direction === 'forward') {
+      // Show Greek word (with article if available)
+      const greekText = word.a ? (word.a + ' ' + word.w) : word.w;
+      cardFront.appendChild(makeEl('div', 'word-primary', greekText));
+      cardFront.appendChild(makeEl('div', 'word-transliteration', word.t));
+    } else {
+      // Show Russian translation
+      cardFront.appendChild(makeEl('div', 'word-primary', word.tr));
+    }
+
+    // Show answer button, hide rating buttons
+    btnShowWrap.classList.remove('hidden');
+    ratingButtons.classList.add('hidden');
+
+    cardStartTime = Date.now();
+  }
+
+  // ── Answer side ───────────────────────────────────────────────────────
+  function revealAnswer() {
+    if (revealed) return;
+    revealed = true;
+
+    const word = words[currentIdx];
+
+    // Build back face content
+    cardBack.innerHTML = '';
+
+    if (direction === 'forward') {
+      // Top label: Greek + transliteration
+      const topLabel = (word.a ? word.a + ' ' : '') + word.w + '  ·  ' + word.t;
+      cardBack.appendChild(makeEl('div', 'back-top-label', topLabel));
+
+      // Big Russian translation
+      cardBack.appendChild(makeEl('div', 'word-translation', word.tr));
+    } else {
+      // Top label: Russian translation
+      cardBack.appendChild(makeEl('div', 'back-top-label', word.tr));
+
+      // Big Greek word + article + transliteration
+      const greekText = word.a ? (word.a + ' ' + word.w) : word.w;
+      cardBack.appendChild(makeEl('div', 'word-translation', greekText));
+      cardBack.appendChild(makeEl('div', 'word-transliteration', word.t));
+    }
+
+    // Verb forms table (if present)
+    if (word.vf) {
+      cardBack.appendChild(buildVerbForms(word.vf));
+    }
+
+    // Example sentence (if present)
+    if (word.ex) {
+      cardBack.appendChild(buildExample(word.ex, word.et));
+    }
+
+    // Flip the card
+    cardEl.classList.add('flipped');
+
+    // Toggle buttons
+    btnShowWrap.classList.add('hidden');
+    ratingButtons.classList.remove('hidden');
+  }
+
+  // ── Rating handler ────────────────────────────────────────────────────
+  function handleRating(rating) {
+    const timeMs = Date.now() - cardStartTime;
+    const word   = words[currentIdx];
+
+    results.push({
+      word_id:   word.id,
+      rating:    rating,
+      time_ms:   timeMs,
+      direction: direction,
+    });
+
+    currentIdx++;
+
+    if (currentIdx < words.length) {
+      // Brief pause then show next question
+      setTimeout(function () {
+        showQuestion(currentIdx);
+      }, 150);
+    } else {
+      // All cards done — update progress bar to 100% then call back
+      updateProgress(words.length);
+      setTimeout(function () {
+        if (typeof onComplete === 'function') {
+          onComplete(results);
+        }
+      }, 300);
+    }
+  }
+
+  // ── Progress & counter helpers ────────────────────────────────────────
+  function updateProgress(idx) {
+    const pct = words.length > 0 ? (idx / words.length) * 100 : 0;
+    progressBar.style.width = pct + '%';
+  }
+
+  function updateCounter(idx) {
+    counterEl.textContent = (idx + 1) + ' / ' + words.length;
+  }
+
+  // ── DOM helpers ───────────────────────────────────────────────────────
+  function makeEl(tag, className, text) {
+    const el = document.createElement(tag);
+    el.className = className;
+    if (text !== undefined) el.textContent = text;
+    return el;
+  }
+
+  /**
+   * Build verb-forms table element.
+   * vf: { p, pt, ao, aot, f, ft }
+   */
+  function buildVerbForms(vf) {
+    const container = document.createElement('div');
+    container.className = 'verb-forms';
+
+    const title = makeEl('div', 'verb-forms-title', 'Формы глагола');
+    container.appendChild(title);
+
+    const rows = [
+      { label: 'Настоящее:', word: vf.p,  trans: vf.pt  },
+      { label: 'Аорист:',    word: vf.ao, trans: vf.aot },
+      { label: 'Будущее:',   word: vf.f,  trans: vf.ft  },
+    ];
+
+    rows.forEach(function (row) {
+      if (!row.word) return;
+      const rowEl = document.createElement('div');
+      rowEl.className = 'verb-form-row';
+
+      const labelEl = makeEl('span', 'verb-form-label', row.label);
+      const valueEl = makeEl('span', 'verb-form-value', row.word);
+      const transEl = makeEl('span', 'verb-form-trans', row.trans ? '(' + row.trans + ')' : '');
+
+      rowEl.appendChild(labelEl);
+      rowEl.appendChild(valueEl);
+      rowEl.appendChild(transEl);
+      container.appendChild(rowEl);
+    });
+
+    return container;
+  }
+
+  /**
+   * Build example sentence block.
+   */
+  function buildExample(greek, russian) {
+    const block = document.createElement('div');
+    block.className = 'example-block';
+
+    block.appendChild(makeEl('div', 'example-greek', greek));
+    if (russian) {
+      block.appendChild(makeEl('div', 'example-russian', russian));
+    }
+    return block;
+  }
+
+  // ── Export ────────────────────────────────────────────────────────────
+  window.initCards = initCards;
+})();

--- a/mini-apps/flashcards/js/decoder.js
+++ b/mini-apps/flashcards/js/decoder.js
@@ -4,34 +4,40 @@
  *   base64url → binary → gzip decompress → JSON parse
  */
 
-/**
- * Decodes an encoded words payload.
- *
- * @param {string} encoded - base64url-encoded, gzip-compressed JSON string
- * @returns {Array} Array of CompactWordPayload objects
- * @throws {Error} if decoding or parsing fails
- */
-function decodeWords(encoded) {
-  // 1. Restore standard base64 characters and padding
-  let b64 = encoded
-    .replace(/-/g, '+')
-    .replace(/_/g, '/');
+(function () {
+  'use strict';
 
-  // Add required '=' padding so length is a multiple of 4
-  while (b64.length % 4 !== 0) {
-    b64 += '=';
+  /**
+   * Decodes an encoded words payload.
+   *
+   * @param {string} encoded - base64url-encoded, gzip-compressed JSON string
+   * @returns {Array} Array of CompactWordPayload objects
+   * @throws {Error} if decoding or parsing fails
+   */
+  function decodeWords(encoded) {
+    // 1. Restore standard base64 characters and padding
+    let b64 = encoded
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+
+    // Add required '=' padding so length is a multiple of 4
+    while (b64.length % 4 !== 0) {
+      b64 += '=';
+    }
+
+    // 2. Decode base64 → binary string → Uint8Array
+    const binaryString = atob(b64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    // 3. Decompress gzip using pako
+    const decompressed = pako.ungzip(bytes, { to: 'string' });
+
+    // 4. Parse JSON and return
+    return JSON.parse(decompressed);
   }
 
-  // 2. Decode base64 → binary string → Uint8Array
-  const binaryString = atob(b64);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-
-  // 3. Decompress gzip using pako
-  const decompressed = pako.ungzip(bytes, { to: 'string' });
-
-  // 4. Parse JSON and return
-  return JSON.parse(decompressed);
-}
+  window.decodeWords = decodeWords;
+})();

--- a/mini-apps/flashcards/js/decoder.js
+++ b/mini-apps/flashcards/js/decoder.js
@@ -1,0 +1,37 @@
+/**
+ * decoder.js
+ * Decodes the `words` URL parameter:
+ *   base64url → binary → gzip decompress → JSON parse
+ */
+
+/**
+ * Decodes an encoded words payload.
+ *
+ * @param {string} encoded - base64url-encoded, gzip-compressed JSON string
+ * @returns {Array} Array of CompactWordPayload objects
+ * @throws {Error} if decoding or parsing fails
+ */
+function decodeWords(encoded) {
+  // 1. Restore standard base64 characters and padding
+  let b64 = encoded
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+
+  // Add required '=' padding so length is a multiple of 4
+  while (b64.length % 4 !== 0) {
+    b64 += '=';
+  }
+
+  // 2. Decode base64 → binary string → Uint8Array
+  const binaryString = atob(b64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  // 3. Decompress gzip using pako
+  const decompressed = pako.ungzip(bytes, { to: 'string' });
+
+  // 4. Parse JSON and return
+  return JSON.parse(decompressed);
+}

--- a/mini-apps/flashcards/js/results.js
+++ b/mini-apps/flashcards/js/results.js
@@ -10,10 +10,10 @@
 
 (function () {
   const RATING_META = [
-    { rating: 0, emoji: '❌', label: 'Again' },
-    { rating: 1, emoji: '⚠️', label: 'Hard'  },
-    { rating: 2, emoji: '✅', label: 'Good'  },
-    { rating: 3, emoji: '⭐', label: 'Easy'  },
+    { rating: 0, emoji: '❌', label: 'Снова'  },
+    { rating: 1, emoji: '⚠️', label: 'Трудно' },
+    { rating: 2, emoji: '✅', label: 'Хорошо' },
+    { rating: 3, emoji: '⭐', label: 'Легко'  },
   ];
 
   function showResults(results, totalWords) {
@@ -69,7 +69,7 @@
     if (tg) {
       tg.MainButton.setText('Отправить результаты');
       tg.MainButton.show();
-      tg.MainButton.onClick(function () {
+      var handler = function () {
         try {
           tg.sendData(JSON.stringify({
             type: 'exercise_results',
@@ -84,7 +84,9 @@
           errEl.textContent = 'Ошибка отправки. Попробуйте снова.';
           document.querySelector('.results-content').appendChild(errEl);
         }
-      });
+      };
+      tg.MainButton.offClick(handler);
+      tg.MainButton.onClick(handler);
     } else {
       // Browser mode — log to console
       console.info('[flashcards] sendData payload:', JSON.stringify({

--- a/mini-apps/flashcards/js/results.js
+++ b/mini-apps/flashcards/js/results.js
@@ -1,0 +1,109 @@
+/**
+ * results.js
+ * Renders the results screen and sends data back to Telegram.
+ *
+ * Public API:
+ *   showResults(results, totalWords)
+ *   - results:    Array of { word_id, rating, time_ms, direction }
+ *   - totalWords: total number of words in the exercise
+ */
+
+(function () {
+  const RATING_META = [
+    { rating: 0, emoji: '❌', label: 'Again' },
+    { rating: 1, emoji: '⚠️', label: 'Hard'  },
+    { rating: 2, emoji: '✅', label: 'Good'  },
+    { rating: 3, emoji: '⭐', label: 'Easy'  },
+  ];
+
+  function showResults(results, totalWords) {
+    // ── Switch screens ────────────────────────────────────────────────
+    document.getElementById('screen-exercise').classList.remove('screen-active');
+    const screenResults = document.getElementById('screen-results');
+    screenResults.classList.add('screen-active');
+
+    // ── Title ─────────────────────────────────────────────────────────
+    document.getElementById('results-title').textContent =
+      'Готово! ' + totalWords + ' ' + pluralWords(totalWords);
+
+    // ── Breakdown ─────────────────────────────────────────────────────
+    const counts = { 0: 0, 1: 0, 2: 0, 3: 0 };
+    let totalTime = 0;
+
+    results.forEach(function (r) {
+      if (counts[r.rating] !== undefined) counts[r.rating]++;
+      totalTime += r.time_ms || 0;
+    });
+
+    const breakdownEl = document.getElementById('results-breakdown');
+    breakdownEl.innerHTML = '';
+
+    RATING_META.forEach(function (meta) {
+      const row = document.createElement('div');
+      row.className = 'results-row';
+
+      const labelWrap = document.createElement('div');
+      labelWrap.className = 'results-row-label';
+      labelWrap.textContent = meta.emoji + '  ' + meta.label;
+
+      const countEl = document.createElement('div');
+      countEl.className = 'results-row-count';
+      countEl.textContent = counts[meta.rating];
+
+      row.appendChild(labelWrap);
+      row.appendChild(countEl);
+      breakdownEl.appendChild(row);
+    });
+
+    // ── Average time ──────────────────────────────────────────────────
+    const avgSec = results.length > 0
+      ? (totalTime / results.length / 1000).toFixed(1)
+      : '0.0';
+
+    document.getElementById('results-avg-time').textContent =
+      'Среднее время: ' + avgSec + ' сек';
+
+    // ── Telegram MainButton ───────────────────────────────────────────
+    const tg = window.Telegram && window.Telegram.WebApp;
+
+    if (tg) {
+      tg.MainButton.setText('Отправить результаты');
+      tg.MainButton.show();
+      tg.MainButton.onClick(function () {
+        try {
+          tg.sendData(JSON.stringify({
+            type: 'exercise_results',
+            results: results,
+          }));
+        } catch (e) {
+          console.error('sendData failed:', e);
+          // Show a brief inline error without crashing
+          const errEl = document.createElement('div');
+          errEl.style.cssText =
+            'color:#ff4444;font-size:0.85rem;text-align:center;margin-top:8px;';
+          errEl.textContent = 'Ошибка отправки. Попробуйте снова.';
+          document.querySelector('.results-content').appendChild(errEl);
+        }
+      });
+    } else {
+      // Browser mode — log to console
+      console.info('[flashcards] sendData payload:', JSON.stringify({
+        type: 'exercise_results',
+        results: results,
+      }));
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+  function pluralWords(n) {
+    const mod10  = n % 10;
+    const mod100 = n % 100;
+    if (mod10 === 1 && mod100 !== 11)              return 'слово';
+    if (mod10 >= 2 && mod10 <= 4 &&
+        (mod100 < 10 || mod100 >= 20))             return 'слова';
+    return 'слов';
+  }
+
+  // ── Export ────────────────────────────────────────────────────────────
+  window.showResults = showResults;
+})();


### PR DESCRIPTION
Closes #34

## Summary

- **`mini-apps/flashcards/index.html`** — single-page shell with three screens: loading/error, exercise, results; loads Telegram WebApp SDK and pako.js from CDN
- **`css/style.css`** — Telegram-theme-aware styles (CSS vars with browser fallbacks), card 3-D flip animation, progress bar, color-coded rating buttons, results breakdown layout
- **`js/decoder.js`** — `decodeWords(encoded)`: base64url → binary → `pako.ungzip` → `JSON.parse`
- **`js/cards.js`** — card state machine: `initCards(words, direction, onComplete)`; renders question/answer sides for both `forward` and `reverse` directions; verb-forms table; example sentences; per-card `time_ms` tracking
- **`js/results.js`** — `showResults(results, totalWords)`: summary with Russian plurals, per-rating breakdown, average time, `Telegram.WebApp.MainButton` to call `sendData()`
- **`js/app.js`** — entry point: Telegram WebApp init, theme application, URL param parsing, error screens, exercise → results flow

## Architecture

Fully offline-first: all data arrives via URL param `?words=<base64url-gzip-json>&dir=forward|reverse`; results sent back via `Telegram.WebApp.sendData()`. No server calls, no build step.

## Test plan

- [ ] Open `index.html?words=<valid-payload>&dir=forward` in a browser — exercise runs, results display, payload logged to console
- [ ] Open with `dir=reverse` — Russian shown on question side, Greek on answer side
- [ ] Open with invalid/missing `words` param — correct error screen shown
- [ ] Open with a word that has `vf` (verb forms) — table renders on answer side
- [ ] Open with a word that has no `vf`, no `ex` — those sections are absent
- [ ] Open inside Telegram — `MainButton` appears on results screen, `sendData` fires
- [ ] Open outside Telegram — browser warning banner shown, no JS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)