### PR TITLE
Fix Mini App exercise flow: empty message text and sendData keyboard type

### DIFF
--- a/config/capabilities/language_learning.yaml
+++ b/config/capabilities/language_learning.yaml
@@ -17,3 +17,5 @@ tools:
     enabled: true
   - tool_id: start_exercise
     enabled: true
+  - tool_id: process_exercise_results
+    enabled: true

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -107,3 +107,7 @@ tools:
   - tool_id: start_exercise
     entrypoint: assistant.extensions.language_learning.tools.start_exercise:start_exercise
     enabled: true
+
+  - tool_id: process_exercise_results
+    entrypoint: assistant.extensions.language_learning.tools.process_exercise_results:process_exercise_results
+    enabled: true

--- a/docs/assistant_v1/LANGUAGE_LEARNING_CONCEPT.md
+++ b/docs/assistant_v1/LANGUAGE_LEARNING_CONCEPT.md
@@ -1,0 +1,541 @@
+# Language Learning Feature — Concept Document
+
+## Overview
+
+Interactive language learning capability for Private Claw, starting with **Modern Greek** vocabulary building via **Telegram Mini Apps** (flashcards).
+
+**User profile:** Beginner — knows Greek alphabet and basic phrases. Native language: Russian.
+
+---
+
+## Architecture Decision: Offline Mini App
+
+### Rationale
+
+The Private Claw server runs on a **home server without a static IP**. Instead of exposing
+an API via tunnels (ngrok, Cloudflare Tunnel), we use a **fully offline Mini App** architecture:
+
+- **Static files** hosted on **GitHub Pages** (separate repo or subtree)
+- **Exercise data** passed to Mini App via **URL query parameters** (base64-encoded JSON)
+- **Results** sent back via **Telegram `sendData()`** → Bot receives `web_app_data` message
+- **No Exercise API, no CORS, no initData validation, no public endpoints**
+
+### Benefits
+
+| Benefit | Details |
+|---------|---------|
+| 🔒 No public API | No attack surface, no auth middleware needed |
+| 🏠 Server stays private | No tunnels, no open ports |
+| ⚡ Instant UX | Cards work without network after page load |
+| 🛠 Simple infra | GitHub Pages + Bot, nothing else |
+| 🔄 Guaranteed delivery | Data flows through Telegram's infrastructure |
+
+### Constraints & Mitigations
+
+| Constraint | Impact | Mitigation |
+|------------|--------|------------|
+| URL length ~4-8 KB usable | Limits words per session | 20-30 words ≈ 3-4 KB raw → fits. Use compression (pako) if needed |
+| `sendData()` is one-shot, closes Mini App | Must collect all results before sending | Aggregate results array, send on "Finish" |
+| No real-time sync during exercise | Can't update store mid-session | Not needed — session is atomic |
+
+---
+
+## Architecture Diagram
+
+```
+                        GitHub Pages
+                        ─────────────
+                        yogson.github.io/private-claw-apps/
+                          └── flashcards/
+                               ├── index.html
+                               ├── app.js
+                               └── style.css
+
+┌──────────────────────────────────────────────────────────────┐
+│                        Telegram                               │
+│                                                               │
+│  1. User: "Давай позанимаемся"                               │
+│                                                               │
+│  2. Agent:                                                    │
+│     → get_due_words(limit=20)                                │
+│     → encode words as base64 JSON                            │
+│     → send WebApp button with URL:                           │
+│       https://yogson.github.io/.../flashcards/               │
+│         ?data={base64_payload}                                │
+│                                                               │
+│  3. ┌────────────────────────────┐                            │
+│     │     Mini App (WebView)     │                            │
+│     │                            │                            │
+│     │  • Decode data from URL    │                            │
+│     │  • Render flashcards       │                            │
+│     │  • User flips & rates      │                            │
+│     │  • Collect all results     │                            │
+│     │                            │                            │
+│     │  [Finish] → sendData()     │──── one-shot ────┐        │
+│     └────────────────────────────┘                   │        │
+│                                                      ▼        │
+│  4. Bot receives web_app_data message:                        │
+│     {results: [{word_id, rating, time_ms}, ...]}              │
+│                                                               │
+│  5. Agent processes results:                                  │
+│     → update_vocabulary_sm2(results)                         │
+│     → respond: "Отлично! 18/20, следующий повтор через 3 дня"│
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+                    ┌─────────────────────┐
+                    │   Home Server        │
+                    │                     │
+                    │  Telegram Bot        │
+                    │  (long polling)      │
+                    │                     │
+                    │  Vocabulary Store    │
+                    │  (JSON files)        │
+                    │                     │
+                    │  SM-2 Engine         │
+                    └─────────────────────┘
+```
+
+---
+
+## Phase 1 Scope
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| **Capability manifest** | `config/capabilities/language_learning.yaml` | Tool definitions for the agent |
+| **Vocabulary store** | `src/assistant/extensions/language_learning/` | Word storage + SM-2 spaced repetition |
+| **Mini App (static)** | Separate GitHub Pages repo/dir | Flashcards HTML/JS/CSS |
+| **Agent tools** | Part of capability | `add_vocabulary`, `get_due_words`, `start_exercise`, `process_exercise_results`, `get_progress` |
+| **Channel integration** | `src/assistant/channels/telegram/` | WebApp button response + `web_app_data` handler |
+
+### What we DON'T need (removed vs original concept)
+
+- ~~Exercise REST API endpoints~~
+- ~~initData HMAC validation middleware~~
+- ~~CORS configuration~~
+- ~~StaticFiles mount in FastAPI~~
+- ~~ExerciseSession server-side state~~
+
+---
+
+## Data Flow Details
+
+### 1. Starting an Exercise
+
+**User says:** "Хочу повторить слова" / "Давай карточки"
+
+**Agent calls tool:** `start_exercise`
+```python
+# Tool: start_exercise
+# 1. Gets due words from vocabulary store
+words = vocabulary_store.get_due_words(user_id, limit=20)
+
+# 2. Builds compact payload
+payload = {
+    "words": [
+        {
+            "id": "abc123",
+            "w": "σπίτι",        # word
+            "t": "spíti",        # transliteration
+            "tr": "дом",         # translation
+            "a": "το",           # article
+            "ex": "Το σπίτι είναι μεγάλο.",  # example (optional)
+            "et": "Дом большой."              # example translation (optional)
+        },
+        # ... more words
+    ]
+}
+
+# 3. Encode: JSON → UTF-8 → gzip → base64url
+encoded = base64url(gzip(json(payload)))
+
+# 4. Build Mini App URL
+url = f"https://yogson.github.io/private-claw-apps/flashcards/?d={encoded}"
+
+# 5. Return as WebApp button response
+```
+
+**Payload size estimate:**
+| Words | Raw JSON | Gzipped | Base64 | Fits URL? |
+|-------|----------|---------|--------|-----------|
+| 10 | ~1.5 KB | ~0.8 KB | ~1.1 KB | ✅ |
+| 20 | ~3.0 KB | ~1.5 KB | ~2.0 KB | ✅ |
+| 30 | ~4.5 KB | ~2.2 KB | ~3.0 KB | ✅ |
+| 50 | ~7.5 KB | ~3.5 KB | ~4.7 KB | ⚠️ borderline |
+
+### 2. Mini App Lifecycle
+
+```javascript
+// app.js (simplified)
+
+// 1. Init Telegram WebApp SDK
+const tg = window.Telegram.WebApp;
+tg.ready();
+tg.expand();
+
+// 2. Decode exercise data from URL
+const params = new URLSearchParams(window.location.search);
+const compressed = base64urlDecode(params.get('d'));
+const data = JSON.parse(pako.ungzip(compressed, { to: 'string' }));
+
+// 3. Render flashcards, collect ratings
+const results = [];  // [{id, rating, time_ms}, ...]
+
+// 4. On finish — send results back via Telegram
+function finishExercise() {
+    tg.sendData(JSON.stringify({
+        type: "exercise_results",
+        results: results
+    }));
+    // Mini App closes automatically after sendData()
+}
+```
+
+### 3. Receiving Results
+
+```python
+# In Telegram channel handler:
+# Bot receives Update with message.web_app_data.data
+
+data = json.loads(update.message.web_app_data.data)
+# data = {"type": "exercise_results", "results": [...]}
+
+# Route to agent or directly to vocabulary store
+# Agent tool: process_exercise_results(results)
+# → Updates SM-2 intervals for each word
+# → Returns summary for agent to comment on
+```
+
+---
+
+## Data Model
+
+### VocabularyEntry
+
+```python
+class VocabularyEntry(BaseModel):
+    id: str                          # UUID
+    user_id: str                     # Owner
+
+    # Word data
+    word: str                        # Greek: "σπίτι"
+    transliteration: str             # Latin: "spíti" (required — user is beginner)
+    translation: str                 # Russian: "дом"
+
+    # Linguistic metadata
+    part_of_speech: str              # noun, verb, adjective, phrase, etc.
+    gender: str | None = None        # m/f/n (for nouns)
+    article: str | None = None       # ο/η/το (for nouns)
+    example_sentence: str | None = None
+    example_translation: str | None = None
+    tags: list[str] = []             # ["basics", "home", "A1"]
+
+    # SM-2 Spaced Repetition fields
+    easiness_factor: float = 2.5     # EF (≥1.3)
+    interval: int = 0                # Days until next review
+    repetitions: int = 0             # Consecutive correct recalls
+    next_review: datetime            # When to show again
+
+    # Stats
+    total_reviews: int = 0
+    correct_reviews: int = 0
+
+    # Timestamps
+    created_at: datetime
+    updated_at: datetime
+```
+
+### Exercise Result (from Mini App via sendData)
+
+```python
+class CardResult(BaseModel):
+    id: str              # word_id
+    rating: int          # 0=Again, 1=Hard, 2=Good, 3=Easy
+    time_ms: int | None  # Response time (optional)
+
+class ExerciseResultPayload(BaseModel):
+    type: str = "exercise_results"
+    results: list[CardResult]
+```
+
+---
+
+## Mini App: Flashcards UI
+
+### Card Front
+
+```
+┌─────────────────────────┐
+│                         │
+│       το σπίτι          │  ← Greek word with article
+│        (spíti)          │  ← Transliteration
+│                         │
+│     [ Tap to flip ]     │
+│                         │
+└─────────────────────────┘
+│  ████████░░░░  12/20    │  ← Progress bar
+└─────────────────────────┘
+```
+
+### Card Back
+
+```
+┌─────────────────────────┐
+│                         │
+│          дом            │  ← Translation
+│                         │
+│   Το σπίτι είναι        │
+│      μεγάλο.            │  ← Example sentence
+│   "Дом большой."        │
+│                         │
+│  ┌──────┐ ┌──────┐     │
+│  │Again │ │ Hard │     │  ← SM-2 rating
+│  └──────┘ └──────┘     │
+│  ┌──────┐ ┌──────┐     │
+│  │ Good │ │ Easy │     │
+│  └──────┘ └──────┘     │
+│                         │
+└─────────────────────────┘
+│  ████████░░░░  12/20    │
+└─────────────────────────┘
+```
+
+### Summary Screen (before sendData)
+
+```
+┌─────────────────────────┐
+│                         │
+│     🎉 Готово!          │
+│                         │
+│   Карточек: 20          │
+│   Again: 2              │
+│   Hard:  3              │
+│   Good:  10             │
+│   Easy:  5              │
+│                         │
+│   Время: 4:32           │
+│                         │
+│   ┌───────────────┐     │
+│   │   Завершить   │     │  ← calls sendData()
+│   └───────────────┘     │
+│                         │
+└─────────────────────────┘
+```
+
+### Tech Stack
+
+- **Vanilla JS** — no framework, minimal bundle for fast WebView loading
+- **Telegram Web App SDK** (`telegram-web-app.js`)
+- **pako.js** — gzip decompression for URL payload
+- CSS with Telegram theme variables (`var(--tg-theme-bg-color)`, etc.)
+- Touch: tap to flip, swipe gestures optional
+
+---
+
+## SM-2 Algorithm (Spaced Repetition)
+
+```python
+def update_sm2(entry: VocabularyEntry, rating: int) -> VocabularyEntry:
+    """
+    rating: 0=Again, 1=Hard, 2=Good, 3=Easy
+    Mapped to SM-2 quality: 0→0, 1→3, 2→4, 3→5
+    """
+    quality_map = {0: 0, 1: 3, 2: 4, 3: 5}
+    q = quality_map[rating]
+
+    # Update easiness factor
+    entry.easiness_factor = max(
+        1.3,
+        entry.easiness_factor + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+    )
+
+    if q < 3:  # Failed recall
+        entry.repetitions = 0
+        entry.interval = 1
+    else:
+        if entry.repetitions == 0:
+            entry.interval = 1
+        elif entry.repetitions == 1:
+            entry.interval = 6
+        else:
+            entry.interval = round(entry.interval * entry.easiness_factor)
+        entry.repetitions += 1
+
+    entry.next_review = now() + timedelta(days=entry.interval)
+    entry.total_reviews += 1
+    if rating >= 2:
+        entry.correct_reviews += 1
+    entry.updated_at = now()
+
+    return entry
+```
+
+---
+
+## Agent Tools (Capability Manifest)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `add_vocabulary` | Add word to user's vocabulary | word, transliteration, translation, part_of_speech, gender?, article?, example_sentence?, example_translation?, tags? |
+| `search_vocabulary` | Search/browse user's vocabulary | query?, tags?, limit? |
+| `get_due_words` | Get words due for review today | limit?, tags? |
+| `start_exercise` | Build exercise payload, return WebApp button | type="flashcards", limit?, tags? |
+| `process_exercise_results` | Update SM-2 after Mini App returns results | results (from web_app_data) |
+| `get_progress` | Learning statistics | period? (week/month/all) |
+
+### Capability Manifest Structure
+
+```yaml
+id: language_learning
+name: Language Learning
+description: >
+  Greek vocabulary learning with spaced repetition flashcards.
+  Can add words, schedule reviews, launch flashcard exercises via Telegram Mini App,
+  and track learning progress.
+
+tools:
+  - name: add_vocabulary
+    description: Add a new word to the user's Greek vocabulary
+    parameters:
+      word: { type: string, required: true, description: "Greek word" }
+      transliteration: { type: string, required: true, description: "Latin transliteration" }
+      translation: { type: string, required: true, description: "Russian translation" }
+      part_of_speech: { type: string, required: true, enum: [noun, verb, adjective, adverb, phrase, other] }
+      gender: { type: string, required: false, enum: [m, f, n], description: "Noun gender" }
+      article: { type: string, required: false, enum: ["ο", "η", "το"], description: "Greek article" }
+      example_sentence: { type: string, required: false }
+      example_translation: { type: string, required: false }
+      tags: { type: array, items: string, required: false }
+
+  - name: start_exercise
+    description: >
+      Launch a flashcard exercise. Returns a Telegram WebApp button.
+      The Mini App runs offline; results come back via sendData().
+    parameters:
+      limit: { type: integer, required: false, default: 20, description: "Max words" }
+      tags: { type: array, items: string, required: false }
+
+  # ... other tools
+```
+
+---
+
+## Channel Integration
+
+### New: WebApp Button Response
+
+The agent needs a way to send a Telegram message with a **WebApp keyboard button**.
+This requires a new response type in the channel layer:
+
+```python
+# New response type for channel
+class WebAppButtonResponse:
+    text: str                  # Message text ("Нажми чтобы начать!")
+    button_text: str           # Button label ("🃏 Карточки")
+    web_app_url: str           # Mini App URL with encoded data
+```
+
+### New: web_app_data Handler
+
+When user completes exercise, Telegram sends `message.web_app_data`:
+
+```python
+# In Telegram channel adapter
+if update.message and update.message.web_app_data:
+    data = json.loads(update.message.web_app_data.data)
+    if data.get("type") == "exercise_results":
+        # Route to agent for processing
+        # Agent calls process_exercise_results tool
+```
+
+---
+
+## GitHub Pages Setup
+
+### Repository Structure
+
+```
+private-claw-apps/          (separate repo or gh-pages branch)
+├── flashcards/
+│   ├── index.html
+│   ├── app.js              ← Main logic
+│   ├── style.css           ← Telegram-themed styles
+│   └── lib/
+│       ├── telegram-web-app.js
+│       └── pako.min.js     ← gzip decompression
+├── shared/
+│   ├── theme.css           ← Shared Telegram theme variables
+│   └── utils.js            ← Shared encoding/decoding
+└── README.md
+```
+
+**URL:** `https://yogson.github.io/private-claw-apps/flashcards/`
+
+---
+
+## Greek-Specific Considerations
+
+- **Transliteration is mandatory** — stored for every word (user is a beginner)
+- **Articles with nouns** — always store and display: ο (m), η (f), το (n)
+- **Stress marks** — preserve accents in both Greek and transliteration (σπίτι → spíti)
+- **UTF-8** — full support throughout pipeline (JSON encoding, URL encoding, display)
+- **Font** — system fonts work for Greek; CSS fallback: `'Noto Sans', sans-serif`
+
+---
+
+## Implementation Order
+
+### Step 1: Vocabulary Store + SM-2 Engine
+- `VocabularyEntry` model
+- JSON file storage (one file per user)
+- SM-2 update logic
+- CRUD operations + due words query
+
+### Step 2: Capability Manifest + Agent Tools
+- `language_learning.yaml` manifest
+- Tool implementations: `add_vocabulary`, `search_vocabulary`, `get_due_words`, `get_progress`
+- Test adding words via chat
+
+### Step 3: Mini App (GitHub Pages)
+- Flashcards HTML/JS/CSS
+- URL payload decoding (base64 + gzip)
+- Card flip UI with SM-2 rating buttons
+- Summary screen + `sendData()`
+- Deploy to GitHub Pages
+
+### Step 4: Channel Integration
+- `start_exercise` tool: builds payload, returns WebApp button
+- WebApp button response type in Telegram channel
+- `web_app_data` handler in Telegram channel
+- `process_exercise_results` tool: SM-2 update from results
+
+### Step 5: End-to-End Testing
+- Add words via chat → launch exercise → flip cards → get results → verify SM-2 update
+
+---
+
+## Future Phases
+
+### Phase 2: Quiz Mini App + Grammar
+- Multiple choice quizzes (Greek → Russian, Russian → Greek)
+- Audio pronunciation (TTS)
+- Verb conjugation drills
+
+### Phase 3: Advanced Exercises
+- Word matching
+- Sentence builder
+- Listening comprehension
+- Analytics dashboard
+- Adaptive difficulty
+
+---
+
+## Open Questions
+
+1. **Storage backend** — JSON files (simple, matches existing store patterns) vs SQLite?
+2. **Reverse cards** — show Russian → Greek direction too, or only Greek → Russian for now?
+3. **Bulk import** — support importing word lists (CSV) from textbooks?
+4. **GitHub Pages repo** — separate repo `private-claw-apps` or `gh-pages` branch in main repo?

--- a/src/assistant/agent/webapp_button_extractor.py
+++ b/src/assistant/agent/webapp_button_extractor.py
@@ -31,6 +31,8 @@ def _extract_pending_webapp_buttons(
         for req_part in msg.parts:
             if not isinstance(req_part, ToolReturnPart):
                 continue
+            if req_part.tool_name != _START_EXERCISE_TOOL_NAME:
+                continue
             result: dict[str, Any] = _parse_tool_result_content(req_part.content)
             actions = result.get("actions")
             if not isinstance(actions, list):

--- a/src/assistant/agent/webapp_button_extractor.py
+++ b/src/assistant/agent/webapp_button_extractor.py
@@ -1,0 +1,51 @@
+"""
+WebApp button extraction from pydantic_ai new_messages.
+
+Scans new messages for tool results that include WebApp button actions and
+returns them so the orchestrator can render an inline WebApp keyboard button.
+"""
+
+from typing import Any
+
+from pydantic_ai.messages import ModelMessage, ModelRequest, ToolReturnPart
+
+from assistant.agent.message_converters import _parse_tool_result_content
+
+_START_EXERCISE_TOOL_NAME = "start_exercise"
+
+
+def _extract_pending_webapp_buttons(
+    new_messages: list[ModelMessage],
+) -> tuple[list[dict[str, str]], str] | None:
+    """Extract WebApp button actions and message text from new_messages if present.
+
+    Scans all ToolReturnPart entries in new_messages and collects any
+    ``actions`` entries that carry a ``web_app_url`` field.  Returns a tuple
+    of (buttons, message) for the first non-empty list found, where message is
+    the ``message`` field from the tool result (empty string if absent).
+    Returns None when no WebApp actions are present.
+    """
+    for msg in new_messages:
+        if not isinstance(msg, ModelRequest):
+            continue
+        for req_part in msg.parts:
+            if not isinstance(req_part, ToolReturnPart):
+                continue
+            result: dict[str, Any] = _parse_tool_result_content(req_part.content)
+            actions = result.get("actions")
+            if not isinstance(actions, list):
+                continue
+            webapp_buttons: list[dict[str, str]] = [
+                {
+                    "label": str(a.get("label", "")),
+                    "web_app_url": str(a["web_app_url"]),
+                    "callback_id": str(a.get("callback_id", "")),
+                    "callback_data": str(a.get("callback_data", "")),
+                }
+                for a in actions
+                if isinstance(a, dict) and a.get("web_app_url")
+            ]
+            if webapp_buttons:
+                message = str(result.get("message", ""))
+                return webapp_buttons, message
+    return None

--- a/src/assistant/api/lifespan.py
+++ b/src/assistant/api/lifespan.py
@@ -30,6 +30,7 @@ from assistant.core.session_context import (
     SessionCapabilityContextService,
     SessionModelContextService,
 )
+from assistant.extensions.language_learning import VocabularyStore
 from assistant.extensions.mcp.bridge import mcp_pool
 from assistant.memory.mem0 import Mem0MemoryWriteService, Mem0RetrievalService
 from assistant.observability.logfire import configure_logfire
@@ -143,6 +144,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         )
         await delegation_coordinator.start()
         app.state.delegation_coordinator = delegation_coordinator
+        vocabulary_store = VocabularyStore(vocabulary_dir=data_root / "vocabulary")
         orchestrator = Orchestrator(
             store=store,
             config=runtime_config,
@@ -153,6 +155,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             delegation_coordinator=delegation_coordinator,
             adapter_cache=adapter_cache,
             session_factory=session_factory,
+            vocabulary_store=vocabulary_store,
         )
         delegation_coordinator.set_completion_callback(
             _build_delegation_feedback_handler(orchestrator, adapter)

--- a/src/assistant/api/orchestrator_handler.py
+++ b/src/assistant/api/orchestrator_handler.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import structlog
 from pydantic_ai import ModelHTTPError, UnexpectedModelBehavior
 
-from assistant.api.utils import build_text_channel_response
+from assistant.api.utils import build_text_channel_response, build_webapp_button_channel_response
 from assistant.channels.telegram import ChannelResponse, NormalizedEvent, TelegramAdapter
 from assistant.channels.telegram.polling import CancellationRegistry
 from assistant.channels.telegram.verbose_state import VerboseStateService
@@ -349,6 +349,14 @@ def _build_orchestrator_handler(
             return None
         session_id = orch_event.session_id
         response_text = orch_result.text
+        if orch_result.pending_webapp_buttons:
+            webapp_text = response_text.strip() or orch_result.pending_webapp_message or ""
+            return build_webapp_button_channel_response(
+                text=webapp_text,
+                session_id=session_id,
+                trace_id=event.trace_id,
+                buttons=orch_result.pending_webapp_buttons,
+            )
         if orch_result.pending_ask is not None:
             prompt_text = orch_result.pending_ask.question
             if response_text.strip():

--- a/src/assistant/api/orchestrator_handler.py
+++ b/src/assistant/api/orchestrator_handler.py
@@ -350,7 +350,11 @@ def _build_orchestrator_handler(
         session_id = orch_event.session_id
         response_text = orch_result.text
         if orch_result.pending_webapp_buttons:
-            webapp_text = response_text.strip() or orch_result.pending_webapp_message or ""
+            webapp_text = (
+                response_text.strip()
+                or orch_result.pending_webapp_message
+                or "Tap the button below to start."
+            )
             return build_webapp_button_channel_response(
                 text=webapp_text,
                 session_id=session_id,

--- a/src/assistant/api/utils.py
+++ b/src/assistant/api/utils.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Literal
 
-from assistant.channels.telegram import ChannelResponse, MessageType
+from assistant.channels.telegram import ActionButton, ChannelResponse, MessageType
 
 
 def build_text_channel_response(
@@ -19,4 +19,39 @@ def build_text_channel_response(
         message_type=MessageType.TEXT,
         text=text,
         parse_mode=parse_mode,
+    )
+
+
+def build_webapp_button_channel_response(
+    text: str,
+    session_id: str,
+    trace_id: str,
+    buttons: list[dict[str, str]],
+    channel: str = "telegram",
+) -> ChannelResponse:
+    """Build an interactive ChannelResponse with one or more WebApp reply-keyboard buttons.
+
+    Uses reply_keyboard (KeyboardButton + WebAppInfo) instead of inline_keyboard so that
+    Telegram.WebApp.sendData() works in the Mini App.  sendData() is only available when
+    the Mini App is launched from a reply-keyboard button; it silently fails when opened
+    from an inline-keyboard button.
+    """
+    actions: list[ActionButton] = [
+        ActionButton(
+            label=btn.get("label", "Open"),
+            callback_id=btn.get("callback_id", ""),
+            callback_data=btn.get("callback_data", ""),
+            web_app_url=btn.get("web_app_url") or None,
+        )
+        for btn in buttons
+    ]
+    return ChannelResponse(
+        response_id=str(uuid.uuid4()),
+        channel=channel,
+        session_id=session_id,
+        trace_id=trace_id,
+        message_type=MessageType.INTERACTIVE,
+        text=text,
+        ui_kind="reply_keyboard",
+        actions=actions,
     )

--- a/src/assistant/channels/telegram/egress.py
+++ b/src/assistant/channels/telegram/egress.py
@@ -16,6 +16,7 @@ from aiogram.types import (
     InlineKeyboardMarkup,
     KeyboardButton,
     ReplyKeyboardMarkup,
+    WebAppInfo,
 )
 
 from assistant.channels.telegram.formatter import format_markdown_for_telegram
@@ -210,23 +211,34 @@ class TelegramEgress:
         if response.message_type != MessageType.INTERACTIVE or not response.actions:
             return None
         if response.ui_kind == "reply_keyboard":
-            keyboard: list[list[KeyboardButton]] = [
-                [KeyboardButton(text=action.label)] for action in response.actions
-            ]
+            keyboard: list[list[KeyboardButton]] = []
+            for action in response.actions:
+                if action.web_app_url:
+                    btn = KeyboardButton(
+                        text=action.label,
+                        web_app=WebAppInfo(url=action.web_app_url),
+                    )
+                else:
+                    btn = KeyboardButton(text=action.label)
+                keyboard.append([btn])
             return ReplyKeyboardMarkup(
                 keyboard=keyboard,
                 resize_keyboard=True,
                 one_time_keyboard=True,
             )
-        inline_buttons: list[list[InlineKeyboardButton]] = [
-            [
-                InlineKeyboardButton(
+        inline_buttons: list[list[InlineKeyboardButton]] = []
+        for action in response.actions:
+            if action.web_app_url:
+                btn = InlineKeyboardButton(
+                    text=action.label,
+                    web_app=WebAppInfo(url=action.web_app_url),
+                )
+            else:
+                btn = InlineKeyboardButton(
                     text=action.label,
                     callback_data=action.callback_data,
                 )
-            ]
-            for action in response.actions
-        ]
+            inline_buttons.append([btn])
         return InlineKeyboardMarkup(inline_keyboard=inline_buttons)
 
     @staticmethod

--- a/src/assistant/channels/telegram/ingress_builders.py
+++ b/src/assistant/channels/telegram/ingress_builders.py
@@ -150,6 +150,32 @@ def build_media_group_event(
     )
 
 
+def build_web_app_data_event(
+    message: dict[str, Any],
+    user_id: int,
+    session_id: str,
+    event_id: str,
+    trace_id: str,
+    created_at: datetime,
+) -> NormalizedEvent:
+    """Build a normalized text event from a Telegram WebApp data submission."""
+    chat_id = message.get("chat", {}).get("id", user_id)
+    web_app_data = message.get("web_app_data", {})
+    data_text: str = web_app_data.get("data", "")
+    return NormalizedEvent(
+        event_id=event_id,
+        event_type=EventType.USER_TEXT_MESSAGE,
+        source=EventSource.TELEGRAM,
+        session_id=session_id,
+        user_id=str(user_id),
+        created_at=created_at,
+        trace_id=trace_id,
+        text=data_text or None,
+        idempotency_key=f"telegram:{message.get('message_id', event_id)}",
+        metadata={"chat_id": chat_id, "message_id": message.get("message_id")},
+    )
+
+
 def build_callback_query_event(
     cq: dict[str, Any], user_id: int, event_id: str, trace_id: str
 ) -> NormalizedEvent:

--- a/src/assistant/channels/telegram/ingress_service.py
+++ b/src/assistant/channels/telegram/ingress_service.py
@@ -20,6 +20,7 @@ from assistant.channels.telegram.ingress_builders import (
     build_media_group_event,
     build_text_event,
     build_voice_event,
+    build_web_app_data_event,
     extract_user_id,
     has_document_or_photo,
     parse_date,
@@ -215,6 +216,10 @@ class TelegramIngress:
             event = build_voice_event(message, user_id, session_id, event_id, trace_id, created_at)
         elif has_document_or_photo(message):
             event = build_attachment_event(
+                message, user_id, session_id, event_id, trace_id, created_at
+            )
+        elif "web_app_data" in message:
+            event = build_web_app_data_event(
                 message, user_id, session_id, event_id, trace_id, created_at
             )
         else:

--- a/src/assistant/channels/telegram/models.py
+++ b/src/assistant/channels/telegram/models.py
@@ -68,6 +68,7 @@ class ActionButton(BaseModel):
     callback_id: str
     callback_data: str
     style: str | None = None
+    web_app_url: str | None = None
 
 
 class ChannelResponse(BaseModel):

--- a/src/assistant/core/orchestrator/models.py
+++ b/src/assistant/core/orchestrator/models.py
@@ -25,3 +25,5 @@ class OrchestratorResult:
 
     text: str
     pending_ask: PendingAskData | None = None
+    pending_webapp_buttons: list[dict[str, str]] | None = None
+    pending_webapp_message: str | None = None

--- a/src/assistant/core/orchestrator/service.py
+++ b/src/assistant/core/orchestrator/service.py
@@ -24,6 +24,7 @@ from assistant.agent.pydantic_ai_agent import (
 )
 from assistant.agent.tools import build_tool_runtime_params
 from assistant.agent.tools.registry import collect_enabled_tool_ids
+from assistant.agent.webapp_button_extractor import _extract_pending_webapp_buttons
 from assistant.core.config.schemas import RuntimeConfig
 from assistant.core.events.models import AttachmentMeta, OrchestratorEvent
 from assistant.core.orchestrator.attachments import AttachmentDownloaderInterface
@@ -430,6 +431,11 @@ class Orchestrator:
         pending_ask = _extract_pending_ask_question(
             new_msgs, session_id=session_id, turn_id=turn_id
         )
+        _webapp_result = _extract_pending_webapp_buttons(new_msgs)
+        pending_webapp_buttons: list[dict[str, str]] | None = None
+        pending_webapp_message: str | None = None
+        if _webapp_result is not None:
+            pending_webapp_buttons, pending_webapp_message = _webapp_result
         initial_persisted = False
         try:
             await persist_turn_initial(
@@ -454,7 +460,12 @@ class Orchestrator:
                 turn_id=turn_id,
                 outcomes=outcomes,
             )
-            return OrchestratorResult(text=response_text, pending_ask=pending_ask)
+            return OrchestratorResult(
+                text=response_text,
+                pending_ask=pending_ask,
+                pending_webapp_buttons=pending_webapp_buttons,
+                pending_webapp_message=pending_webapp_message,
+            )
         except Exception:
             if initial_persisted:
                 await persist_turn_terminal_failed(

--- a/src/assistant/extensions/language_learning/tools/process_exercise_results.py
+++ b/src/assistant/extensions/language_learning/tools/process_exercise_results.py
@@ -1,0 +1,134 @@
+"""
+Component ID: CMP_EXT_LANGUAGE_LEARNING
+
+Process exercise results tool for the language learning agent.
+Accepts the JSON payload sent by the Mini App via web_app_data and applies
+SM-2 spaced-repetition updates to the user's vocabulary store.
+"""
+
+import json
+from typing import Any
+
+import structlog
+from pydantic import ValidationError
+from pydantic_ai import RunContext
+
+from assistant.agent.tools.deps import TurnDeps
+from assistant.extensions.language_learning.models import (
+    CardDirection,
+    ExerciseResultPayload,
+    LearningStatus,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+async def process_exercise_results(
+    ctx: RunContext[TurnDeps],
+    results_json: str,
+) -> dict[str, Any]:
+    """Process flashcard exercise results received from the Mini App.
+
+    Call this tool when the user submits exercise results (the message text
+    will be a JSON string matching the ExerciseResultPayload schema).
+
+    Args:
+        results_json: JSON string containing exercise results from the Mini App.
+            Must match the ExerciseResultPayload schema with a ``results`` list
+            of CardResult objects (word_id, rating 0-3, optional time_ms,
+            optional direction).
+    """
+    user_id = ctx.deps.user_id
+    store = ctx.deps.vocabulary_store
+    if user_id is None or store is None:
+        logger.warning("ext.language_learning.process_exercise_results", status="unavailable")
+        return {"status": "unavailable", "reason": "language learning not configured"}
+
+    # Parse JSON payload
+    try:
+        raw = json.loads(results_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        return {
+            "status": "rejected_invalid",
+            "reason": f"Invalid JSON payload: {exc}",
+        }
+
+    # Validate against ExerciseResultPayload schema
+    try:
+        payload = ExerciseResultPayload.model_validate(raw)
+    except ValidationError as exc:
+        return {
+            "status": "rejected_invalid",
+            "reason": f"Payload does not match expected schema: {exc}",
+        }
+
+    if not payload.results:
+        return {
+            "status": "rejected_invalid",
+            "reason": "No results provided in payload.",
+        }
+
+    logger.info(
+        "ext.language_learning.process_exercise_results",
+        user_id=user_id,
+        result_count=len(payload.results),
+    )
+
+    try:
+        updated_entries = await store.process_exercise_results(
+            user_id=user_id,
+            results=payload.results,
+        )
+    except Exception as exc:
+        logger.warning("ext.language_learning.process_exercise_results", error=str(exc))
+        return {"status": "error", "reason": str(exc)}
+
+    # Build per-status breakdown of updated entries
+    status_counts: dict[str, int] = {}
+    updated_count = 0
+    not_found_count = 0
+
+    for _word_id, entry in updated_entries.items():
+        if entry is None:
+            not_found_count += 1
+            continue
+        updated_count += 1
+        status_key = entry.learning_status.value
+        status_counts[status_key] = status_counts.get(status_key, 0) + 1
+
+    # Build human-readable summary
+    direction_summary: dict[str, int] = {}
+    for result in payload.results:
+        dir_key = (
+            result.direction.value
+            if isinstance(result.direction, CardDirection)
+            else str(result.direction)
+        )
+        direction_summary[dir_key] = direction_summary.get(dir_key, 0) + 1
+
+    summary_parts: list[str] = [f"Updated {updated_count} word(s)."]
+    if status_counts:
+        breakdown = ", ".join(
+            f"{count} {LearningStatus(status).value}" for status, count in status_counts.items()
+        )
+        summary_parts.append(f"Status breakdown: {breakdown}.")
+    if not_found_count:
+        summary_parts.append(f"{not_found_count} word(s) not found and skipped.")
+
+    summary = " ".join(summary_parts)
+
+    logger.info(
+        "ext.language_learning.process_exercise_results",
+        status="ok",
+        updated=updated_count,
+        not_found=not_found_count,
+        status_counts=status_counts,
+    )
+    return {
+        "status": "ok",
+        "summary": summary,
+        "updated_count": updated_count,
+        "not_found_count": not_found_count,
+        "status_breakdown": status_counts,
+        "direction_summary": direction_summary,
+    }

--- a/src/assistant/extensions/language_learning/tools/start_exercise.py
+++ b/src/assistant/extensions/language_learning/tools/start_exercise.py
@@ -155,4 +155,12 @@ async def start_exercise(
         },
         "direction": direction,
         "message": message,
+        "actions": [
+            {
+                "label": "🃏 Начать упражнение",
+                "web_app_url": webapp_url,
+                "callback_id": "start_exercise",
+                "callback_data": "",
+            }
+        ],
     }

--- a/tests/assistant/agent/test_webapp_button_extractor.py
+++ b/tests/assistant/agent/test_webapp_button_extractor.py
@@ -1,0 +1,132 @@
+"""Unit tests for _extract_pending_webapp_buttons."""
+
+import json
+
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, ToolReturnPart
+
+from assistant.agent.webapp_button_extractor import _extract_pending_webapp_buttons
+
+
+def _make_tool_return_part(
+    tool_name: str,
+    content: dict,
+    tool_call_id: str = "call_1",
+) -> ToolReturnPart:
+    return ToolReturnPart(
+        tool_name=tool_name,
+        content=json.dumps(content),
+        tool_call_id=tool_call_id,
+    )
+
+
+def _make_request_with_tool_return(
+    tool_name: str,
+    content: dict,
+) -> ModelRequest:
+    return ModelRequest(parts=[_make_tool_return_part(tool_name, content)])
+
+
+class TestExtractPendingWebappButtons:
+    def test_happy_path_returns_buttons_and_message(self) -> None:
+        """Tool result with actions + web_app_url + message returns buttons tuple."""
+        msg = _make_request_with_tool_return(
+            tool_name="start_exercise",
+            content={
+                "status": "exercise_ready",
+                "message": "Your exercise is ready!",
+                "actions": [
+                    {
+                        "label": "🃏 Start",
+                        "web_app_url": "https://example.com/exercise",
+                        "callback_id": "start_exercise",
+                        "callback_data": "",
+                    }
+                ],
+            },
+        )
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is not None
+        buttons, message = result
+        assert len(buttons) == 1
+        assert buttons[0]["label"] == "🃏 Start"
+        assert buttons[0]["web_app_url"] == "https://example.com/exercise"
+        assert buttons[0]["callback_id"] == "start_exercise"
+        assert buttons[0]["callback_data"] == ""
+        assert message == "Your exercise is ready!"
+
+    def test_no_web_app_url_in_actions_returns_none(self) -> None:
+        """Actions without web_app_url are ignored; returns None when none qualify."""
+        msg = _make_request_with_tool_return(
+            tool_name="start_exercise",
+            content={
+                "status": "exercise_ready",
+                "actions": [
+                    {
+                        "label": "Something",
+                        "callback_id": "foo",
+                        "callback_data": "",
+                        # no web_app_url
+                    }
+                ],
+            },
+        )
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is None
+
+    def test_no_actions_key_returns_none(self) -> None:
+        """Tool result without an 'actions' key returns None."""
+        msg = _make_request_with_tool_return(
+            tool_name="start_exercise",
+            content={"status": "no_words_due", "message": "Nothing to do."},
+        )
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is None
+
+    def test_non_start_exercise_tool_is_ignored(self) -> None:
+        """ToolReturnPart from a different tool is skipped even if it has web_app_url."""
+        msg = _make_request_with_tool_return(
+            tool_name="some_other_tool",
+            content={
+                "actions": [
+                    {
+                        "label": "Click",
+                        "web_app_url": "https://example.com/other",
+                        "callback_id": "other",
+                        "callback_data": "",
+                    }
+                ],
+            },
+        )
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is None
+
+    def test_no_tool_return_part_in_response_returns_none(self) -> None:
+        """ModelResponse messages (no ToolReturnPart) return None."""
+        msg = ModelResponse(parts=[TextPart(content="Hello!")], model_name="claude-3")
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is None
+
+    def test_empty_message_list_returns_none(self) -> None:
+        """Empty new_messages list returns None."""
+        result = _extract_pending_webapp_buttons([])
+        assert result is None
+
+    def test_message_field_defaults_to_empty_string(self) -> None:
+        """When tool result has no 'message' field, returned message is empty string."""
+        msg = _make_request_with_tool_return(
+            tool_name="start_exercise",
+            content={
+                "actions": [
+                    {
+                        "label": "Go",
+                        "web_app_url": "https://example.com/exercise",
+                        "callback_id": "start_exercise",
+                        "callback_data": "",
+                    }
+                ],
+            },
+        )
+        result = _extract_pending_webapp_buttons([msg])
+        assert result is not None
+        _, message = result
+        assert message == ""

--- a/tests/assistant/channels/telegram/test_egress.py
+++ b/tests/assistant/channels/telegram/test_egress.py
@@ -188,6 +188,34 @@ class TestTelegramEgresSend:
         assert markup.keyboard[0][0].text == "A"
         assert markup.keyboard[1][0].text == "B"
 
+    def test_reply_keyboard_with_webapp_url_uses_webapp_info(self) -> None:
+        egress = TelegramEgress(bot_token="12345:tok")
+        response = ChannelResponse(
+            response_id=str(uuid.uuid4()),
+            channel="telegram",
+            session_id="tg:123",
+            trace_id="trace-4",
+            message_type=MessageType.INTERACTIVE,
+            text="Start exercise:",
+            ui_kind="reply_keyboard",
+            actions=[
+                ActionButton(
+                    label="🃏 Начать упражнение",
+                    callback_id="start_exercise",
+                    callback_data="",
+                    web_app_url="https://private-claw.pages.dev?words=abc&dir=forward",
+                ),
+            ],
+        )
+        markup = egress._build_reply_markup(response)
+        assert markup is not None
+        assert hasattr(markup, "keyboard")
+        assert len(markup.keyboard) == 1
+        btn = markup.keyboard[0][0]
+        assert btn.text == "🃏 Начать упражнение"
+        assert btn.web_app is not None
+        assert btn.web_app.url == "https://private-claw.pages.dev?words=abc&dir=forward"
+
     def test_split_text_prefers_newline_boundary(self) -> None:
         egress = TelegramEgress(bot_token="12345:tok")
         text = ("A" * 4090) + "\n" + ("B" * 100)

--- a/tests/assistant/channels/telegram/test_ingress.py
+++ b/tests/assistant/channels/telegram/test_ingress.py
@@ -6,7 +6,8 @@ import pytest
 
 from assistant.channels.telegram.allowlist import AllowlistGuard, UnauthorizedUserError
 from assistant.channels.telegram.ingress import _VOICE_MISSING_TRANSCRIPT, TelegramIngress
-from assistant.channels.telegram.models import EventType
+from assistant.channels.telegram.ingress_builders import build_web_app_data_event, parse_date
+from assistant.channels.telegram.models import EventSource, EventType
 
 
 def _make_ingress(allowed: list[int] | None = None) -> TelegramIngress:
@@ -216,3 +217,139 @@ class TestAttachmentMessage:
         assert event.attachment.file_id == "doc_md_1"
         assert event.attachment.file_name == "architecture_improvements_exercise.md"
         assert event.attachment.mime_type == "text/markdown"
+
+
+class TestWebAppDataMessage:
+    def _web_app_update(
+        self,
+        user_id: int = 123456,
+        chat_id: int = 123456,
+        message_id: int = 20,
+        data: str = '{"type":"exercise_results","results":[]}',
+        button_text: str = "🃏 Start",
+    ) -> dict:
+        return {
+            "message": {
+                "message_id": message_id,
+                "from": {"id": user_id},
+                "chat": {"id": chat_id},
+                "date": 1700000000,
+                "web_app_data": {
+                    "data": data,
+                    "button_text": button_text,
+                },
+            }
+        }
+
+    def test_web_app_data_routes_to_text_event(self) -> None:
+        """web_app_data message is normalized as USER_TEXT_MESSAGE."""
+        ingress = _make_ingress()
+        event = ingress.normalize(self._web_app_update())
+        assert event is not None
+        assert event.event_type == EventType.USER_TEXT_MESSAGE
+
+    def test_web_app_data_text_contains_payload(self) -> None:
+        """The JSON payload from web_app_data.data becomes event.text."""
+        ingress = _make_ingress()
+        payload = '{"type":"exercise_results","results":[]}'
+        event = ingress.normalize(self._web_app_update(data=payload))
+        assert event is not None
+        assert event.text == payload
+
+    def test_web_app_data_session_and_user(self) -> None:
+        """Session ID and user ID are set correctly from chat/from fields."""
+        ingress = _make_ingress()
+        event = ingress.normalize(self._web_app_update(user_id=123456, chat_id=123456))
+        assert event is not None
+        assert event.user_id == "123456"
+        assert event.session_id == "tg:123456"
+
+    def test_web_app_data_idempotency_key_uses_message_id(self) -> None:
+        """Idempotency key includes the Telegram message_id."""
+        ingress = _make_ingress()
+        event = ingress.normalize(self._web_app_update(message_id=99))
+        assert event is not None
+        assert "99" in (event.idempotency_key or "")
+
+    def test_web_app_data_unknown_user_raises(self) -> None:
+        """Unauthorized user raises UnauthorizedUserError."""
+        ingress = _make_ingress(allowed=[111])
+        with pytest.raises(UnauthorizedUserError):
+            ingress.normalize(self._web_app_update(user_id=999))
+
+    def test_web_app_data_empty_data_gives_none_text(self) -> None:
+        """Empty data field results in event.text being None."""
+        ingress = _make_ingress()
+        event = ingress.normalize(self._web_app_update(data=""))
+        assert event is not None
+        assert event.text is None
+
+
+class TestBuildWebAppDataEvent:
+    def test_build_web_app_data_event_happy_path(self) -> None:
+        """build_web_app_data_event extracts data and sets correct event fields."""
+        message = {
+            "message_id": 42,
+            "from": {"id": 123456},
+            "chat": {"id": 123456},
+            "date": 1700000000,
+            "web_app_data": {
+                "data": '{"type":"exercise_results"}',
+                "button_text": "Start",
+            },
+        }
+        created_at = parse_date(message["date"])
+        event = build_web_app_data_event(
+            message,
+            user_id=123456,
+            session_id="tg:123456",
+            event_id="evt-1",
+            trace_id="trace-1",
+            created_at=created_at,
+        )
+        assert event.event_type == EventType.USER_TEXT_MESSAGE
+        assert event.source == EventSource.TELEGRAM
+        assert event.text == '{"type":"exercise_results"}'
+        assert event.session_id == "tg:123456"
+        assert event.user_id == "123456"
+        assert "42" in event.idempotency_key
+
+    def test_build_web_app_data_event_missing_data_field(self) -> None:
+        """When web_app_data.data is absent, event.text is None."""
+        message = {
+            "message_id": 43,
+            "from": {"id": 123456},
+            "chat": {"id": 123456},
+            "date": 1700000000,
+            "web_app_data": {},
+        }
+        created_at = parse_date(message["date"])
+        event = build_web_app_data_event(
+            message,
+            user_id=123456,
+            session_id="tg:123456",
+            event_id="evt-2",
+            trace_id="trace-2",
+            created_at=created_at,
+        )
+        assert event.text is None
+
+    def test_build_web_app_data_event_metadata_contains_chat_id(self) -> None:
+        """Metadata chat_id is populated from message.chat.id."""
+        message = {
+            "message_id": 44,
+            "from": {"id": 123456},
+            "chat": {"id": 999888},
+            "date": 1700000000,
+            "web_app_data": {"data": "hello"},
+        }
+        created_at = parse_date(message["date"])
+        event = build_web_app_data_event(
+            message,
+            user_id=123456,
+            session_id="tg:999888",
+            event_id="evt-3",
+            trace_id="trace-3",
+            created_at=created_at,
+        )
+        assert event.metadata.get("chat_id") == 999888

--- a/tests/assistant/extensions/language_learning/tools/test_process_exercise_results.py
+++ b/tests/assistant/extensions/language_learning/tools/test_process_exercise_results.py
@@ -1,0 +1,181 @@
+"""Tests for process_exercise_results tool."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from assistant.agent.tools.deps import TurnDeps
+from assistant.extensions.language_learning.models import (
+    LearningStatus,
+    PartOfSpeech,
+    VocabularyEntry,
+)
+from assistant.extensions.language_learning.store import VocabularyStore
+from assistant.extensions.language_learning.tools.process_exercise_results import (
+    process_exercise_results,
+)
+
+
+@pytest.fixture
+def vocabulary_dir(tmp_path: Path) -> Path:
+    return tmp_path / "vocabulary"
+
+
+@pytest.fixture
+def store(vocabulary_dir: Path) -> VocabularyStore:
+    return VocabularyStore(vocabulary_dir)
+
+
+def _make_ctx(store: VocabularyStore | None, user_id: str = "user-1") -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps = TurnDeps(
+        writes_approved=[],
+        seen_intent_ids=set(),
+        user_id=user_id,
+        vocabulary_store=store,
+    )
+    return ctx
+
+
+def _make_new_entry(word: str, user_id: str = "user-1") -> VocabularyEntry:
+    now = datetime.now(UTC)
+    return VocabularyEntry(
+        user_id=user_id,
+        word=word,
+        transliteration=f"trans_{word}",
+        translation="тест",
+        part_of_speech=PartOfSpeech.NOUN,
+        learning_status=LearningStatus.NEW,
+        next_review=now,
+        reverse_next_review=now,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_valid_payload(word_ids: list[str]) -> str:
+    results = [
+        {"word_id": wid, "rating": 3, "time_ms": 1200, "direction": "forward"} for wid in word_ids
+    ]
+    return json.dumps({"type": "exercise_results", "results": results})
+
+
+class TestProcessExerciseResults:
+    @pytest.mark.asyncio
+    async def test_valid_payload_updates_words(self, store: VocabularyStore) -> None:
+        """Valid payload with known word IDs updates and returns ok status."""
+        entry = _make_new_entry("σπίτι")
+        await store.add(entry)
+        # Fetch the saved entry to get the real UUID
+        all_entries = await store.list_entries("user-1")
+        word_id = all_entries[0].id
+
+        payload = _make_valid_payload([str(word_id)])
+        ctx = _make_ctx(store)
+        result = await process_exercise_results(ctx, payload)
+
+        assert result["status"] == "ok"
+        assert result["updated_count"] == 1
+        assert result["not_found_count"] == 0
+        assert "summary" in result
+        assert "status_breakdown" in result
+        assert "direction_summary" in result
+
+    @pytest.mark.asyncio
+    async def test_valid_payload_counts_not_found(self, store: VocabularyStore) -> None:
+        """Word IDs that do not exist are counted as not_found."""
+        payload = _make_valid_payload(["00000000-0000-0000-0000-000000000000"])
+        ctx = _make_ctx(store)
+        result = await process_exercise_results(ctx, payload)
+
+        assert result["status"] == "ok"
+        assert result["updated_count"] == 0
+        assert result["not_found_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_rejected(self, store: VocabularyStore) -> None:
+        """Non-JSON input returns rejected_invalid."""
+        ctx = _make_ctx(store)
+        result = await process_exercise_results(ctx, "not-valid-json{{")
+        assert result["status"] == "rejected_invalid"
+        assert "Invalid JSON" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_schema_mismatch_returns_rejected(self, store: VocabularyStore) -> None:
+        """Valid JSON that does not match ExerciseResultPayload schema is rejected."""
+        ctx = _make_ctx(store)
+        bad_payload = json.dumps({"type": "exercise_results", "results": "not-a-list"})
+        result = await process_exercise_results(ctx, bad_payload)
+        assert result["status"] == "rejected_invalid"
+        assert "schema" in result["reason"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_results_list_returns_rejected(self, store: VocabularyStore) -> None:
+        """Payload with an empty results list is rejected."""
+        ctx = _make_ctx(store)
+        payload = json.dumps({"type": "exercise_results", "results": []})
+        result = await process_exercise_results(ctx, payload)
+        assert result["status"] == "rejected_invalid"
+
+    @pytest.mark.asyncio
+    async def test_store_exception_returns_error(self) -> None:
+        """When the store raises, the tool returns error status."""
+        mock_store = MagicMock()
+        mock_store.process_exercise_results = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        ctx = MagicMock()
+        ctx.deps = TurnDeps(
+            writes_approved=[],
+            seen_intent_ids=set(),
+            user_id="user-1",
+            vocabulary_store=mock_store,
+        )
+        payload = _make_valid_payload(["00000000-0000-0000-0000-000000000001"])
+        result = await process_exercise_results(ctx, payload)
+        assert result["status"] == "error"
+        assert "disk full" in result["reason"]
+
+    @pytest.mark.asyncio
+    async def test_unavailable_without_store(self) -> None:
+        """Returns unavailable when vocabulary_store is None."""
+        ctx = MagicMock()
+        ctx.deps = TurnDeps(writes_approved=[], seen_intent_ids=set())
+        result = await process_exercise_results(ctx, "{}")
+        assert result["status"] == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_without_user_id(self, store: VocabularyStore) -> None:
+        """Returns unavailable when user_id is None."""
+        ctx = MagicMock()
+        ctx.deps = TurnDeps(
+            writes_approved=[],
+            seen_intent_ids=set(),
+            user_id=None,
+            vocabulary_store=store,
+        )
+        result = await process_exercise_results(ctx, "{}")
+        assert result["status"] == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_direction_summary_populated(self, store: VocabularyStore) -> None:
+        """direction_summary contains a count per direction used in results."""
+        entry = _make_new_entry("νερό")
+        await store.add(entry)
+        all_entries = await store.list_entries("user-1")
+        word_id = str(all_entries[0].id)
+
+        payload = json.dumps(
+            {
+                "type": "exercise_results",
+                "results": [
+                    {"word_id": word_id, "rating": 2, "direction": "forward"},
+                ],
+            }
+        )
+        ctx = _make_ctx(store)
+        result = await process_exercise_results(ctx, payload)
+        assert result["status"] == "ok"
+        assert result["direction_summary"].get("forward", 0) >= 1


### PR DESCRIPTION
## Summary

Two bugs prevented the vocabulary flashcard Mini App from working end-to-end:

- **Empty message text** — `build_webapp_button_channel_response()` produced a `ChannelResponse` with blank `text`, causing Telegram to reject it with _"message text is empty"_. The orchestrator handler now uses the tool result's `message` field as fallback text via a new `pending_webapp_message` field on `OrchestratorResult`.
- **`sendData()` silently failing** — `Telegram.WebApp.sendData()` only works when the Mini App is opened from a **reply-keyboard** button (`KeyboardButton` + `WebAppInfo`). Opening via an inline-keyboard button gives the Mini App no `sendData` capability. Changed `ui_kind` to `reply_keyboard` and extended egress rendering to attach `WebAppInfo` when `action.web_app_url` is set.

Additional changes included in this PR:
- New `process_exercise_results` tool registered in config and implemented
- `web_app_data` Telegram messages now handled in ingress (builder + service routing)
- `VocabularyStore` wired into orchestrator lifespan
- `start_exercise` tool result now includes an `actions` list with the WebApp button
- Language-learning concept doc added under `docs/`

## Changes by area

| Area | Files |
|---|---|
| WebApp button extraction | `src/assistant/agent/webapp_button_extractor.py` (new) |
| Orchestrator result model | `src/assistant/core/orchestrator/models.py`, `service.py` |
| API handler routing | `src/assistant/api/orchestrator_handler.py`, `utils.py` |
| Telegram egress (keyboard rendering) | `src/assistant/channels/telegram/egress.py`, `models.py` |
| Telegram ingress (web_app_data) | `src/assistant/channels/telegram/ingress_builders.py`, `ingress_service.py` |
| Exercise tools | `start_exercise.py`, `process_exercise_results.py` (new) |
| Config | `config/capabilities/language_learning.yaml`, `config/tools.yaml` |
| Tests | `tests/assistant/channels/telegram/test_egress.py` |

## Test plan

- [x] All 1 055 existing tests pass (`make test`)
- [x] New test `test_reply_keyboard_with_webapp_url_uses_webapp_info` verifies `WebAppInfo` is attached to the reply-keyboard button
- [ ] Manual smoke test: send `/exercise` → bot responds with reply-keyboard button → open Mini App → complete exercise → `sendData()` delivers results back to bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)