### PR TITLE
feat(mini-apps): Word-Translation Matching Exercise (#38)

### DIFF
--- a/config/capabilities/language_learning.yaml
+++ b/config/capabilities/language_learning.yaml
@@ -2,7 +2,13 @@ capability_id: language_learning
 prompt: |
   ### Language Learning (Greek)
   You help the user learn Modern Greek vocabulary. You can add words to their dictionary,
-  search their vocabulary, manage word statuses, and start flashcard exercises.
+  search their vocabulary, manage word statuses, and start exercises.
+
+  Two exercise types are available:
+  - **Flashcards** (`start_exercise`): recall-based — given one side, produce the other from memory.
+    Best for deep learning; supports up to 30 words per session.
+  - **Matching** (`start_matching_exercise`): recognition-based — tap to pair Greek words with their
+    Russian translations. Great for variety and lighter review; limited to 8–10 word pairs.
 
   When adding words, always provide complete and accurate linguistic metadata.
   For nouns: include gender and article. For verbs: include all three tense forms.
@@ -16,6 +22,8 @@ tools:
   - tool_id: set_word_status
     enabled: true
   - tool_id: start_exercise
+    enabled: true
+  - tool_id: start_matching_exercise
     enabled: true
   - tool_id: process_exercise_results
     enabled: true

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -111,3 +111,7 @@ tools:
   - tool_id: process_exercise_results
     entrypoint: assistant.extensions.language_learning.tools.process_exercise_results:process_exercise_results
     enabled: true
+
+  - tool_id: start_matching_exercise
+    entrypoint: assistant.extensions.language_learning.tools.start_matching_exercise:start_matching_exercise
+    enabled: true

--- a/mini-apps/matching/css/style.css
+++ b/mini-apps/matching/css/style.css
@@ -1,0 +1,337 @@
+/* ============================================================
+   Telegram theme CSS variables with browser fallbacks
+   ============================================================ */
+:root {
+  --tg-theme-bg-color: #ffffff;
+  --tg-theme-text-color: #000000;
+  --tg-theme-hint-color: #999999;
+  --tg-theme-link-color: #2481cc;
+  --tg-theme-button-color: #2481cc;
+  --tg-theme-button-text-color: #ffffff;
+  --tg-theme-secondary-bg-color: #f5f5f5;
+}
+
+/* ============================================================
+   Reset & base
+   ============================================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               Helvetica, Arial, sans-serif;
+  background-color: var(--tg-theme-bg-color);
+  color: var(--tg-theme-text-color);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* ============================================================
+   Screens
+   ============================================================ */
+.screen {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.screen-active {
+  display: flex;
+}
+
+/* ============================================================
+   Loading screen
+   ============================================================ */
+#screen-loading {
+  justify-content: center;
+}
+
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.loading-text {
+  color: var(--tg-theme-hint-color);
+  font-size: 1rem;
+}
+
+/* Spinner */
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--tg-theme-secondary-bg-color);
+  border-top-color: var(--tg-theme-button-color);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Error state */
+.error-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+}
+
+.error-icon {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.error-message {
+  font-size: 1rem;
+  color: var(--tg-theme-text-color);
+  max-width: 320px;
+}
+
+/* Warning banner for browser mode */
+.browser-warning {
+  background: #fff3cd;
+  color: #856404;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  text-align: center;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+}
+
+/* ============================================================
+   Exercise screen
+   ============================================================ */
+#screen-exercise {
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* ── Header ── */
+#exercise-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px 4px;
+  flex-shrink: 0;
+}
+
+.header-stat {
+  font-size: 0.82rem;
+  color: var(--tg-theme-hint-color);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Progress bar ── */
+#progress-bar-wrap {
+  width: 100%;
+  height: 3px;
+  background: var(--tg-theme-secondary-bg-color);
+  flex-shrink: 0;
+}
+
+#progress-bar {
+  height: 100%;
+  background: var(--tg-theme-button-color);
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+/* ── Selected indicator ── */
+.selected-indicator {
+  width: 100%;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--tg-theme-button-color);
+  background: transparent;
+  flex-shrink: 0;
+  min-height: 28px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selected-indicator.hidden {
+  visibility: hidden;
+}
+
+/* ============================================================
+   Matching grid
+   ============================================================ */
+.matching-grid {
+  display: flex;
+  gap: 8px;
+  padding: 0 10px 10px;
+  width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  align-items: flex-start;
+}
+
+.match-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* ── Tile ── */
+.match-tile {
+  width: 100%;
+  min-height: 52px;
+  padding: 10px 12px;
+  background: var(--tg-theme-secondary-bg-color);
+  border-radius: 12px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--tg-theme-text-color);
+  text-align: center;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.3;
+  word-break: break-word;
+  border: 2px solid transparent;
+  transition: background 0.15s, border-color 0.15s, opacity 0.3s, transform 0.1s;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.match-tile:active {
+  transform: scale(0.97);
+}
+
+/* Selected (left column tap) */
+.match-tile.selected {
+  border-color: var(--tg-theme-button-color);
+  background: color-mix(in srgb, var(--tg-theme-button-color) 12%, var(--tg-theme-secondary-bg-color));
+}
+
+/* Correct match flash */
+.match-tile.correct {
+  background: #27ae60;
+  color: #ffffff;
+  border-color: #27ae60;
+}
+
+/* Wrong match flash */
+.match-tile.wrong {
+  background: #ff4444;
+  color: #ffffff;
+  border-color: #ff4444;
+  animation: shake 0.4s ease;
+}
+
+/* Matched (dimmed) */
+.match-tile.matched {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* Shake animation for wrong matches */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%       { transform: translateX(-5px); }
+  40%       { transform: translateX(5px); }
+  60%       { transform: translateX(-4px); }
+  80%       { transform: translateX(4px); }
+}
+
+/* ============================================================
+   Results screen
+   ============================================================ */
+#screen-results {
+  justify-content: center;
+  padding: 24px 20px 80px;
+}
+
+.results-content {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.results-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--tg-theme-text-color);
+}
+
+.results-time {
+  font-size: 1rem;
+  color: var(--tg-theme-hint-color);
+  text-align: center;
+}
+
+.results-breakdown {
+  width: 100%;
+  background: var(--tg-theme-secondary-bg-color);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.results-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+}
+
+.results-row-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--tg-theme-text-color);
+}
+
+.results-row-count {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--tg-theme-text-color);
+}
+
+/* ============================================================
+   Utility
+   ============================================================ */
+.hidden {
+  display: none !important;
+}

--- a/mini-apps/matching/css/style.css
+++ b/mini-apps/matching/css/style.css
@@ -235,6 +235,7 @@ body {
 /* Selected (left column tap) */
 .match-tile.selected {
   border-color: var(--tg-theme-button-color);
+  background: var(--tg-theme-secondary-bg-color); /* fallback for Chrome <111 / older Telegram WebView */
   background: color-mix(in srgb, var(--tg-theme-button-color) 12%, var(--tg-theme-secondary-bg-color));
 }
 

--- a/mini-apps/matching/index.html
+++ b/mini-apps/matching/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Word Matching</title>
+
+  <!-- Telegram WebApp SDK -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+
+  <!-- pako.js for gzip decompression -->
+  <script src="https://cdn.jsdelivr.net/npm/pako@2/dist/pako.min.js"></script>
+
+  <!-- App styles -->
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+
+  <!-- Loading / error screen -->
+  <div id="screen-loading" class="screen screen-active">
+    <div class="loading-content">
+      <div class="spinner"></div>
+      <p class="loading-text">Загрузка...</p>
+    </div>
+  </div>
+
+  <!-- Exercise screen -->
+  <div id="screen-exercise" class="screen">
+    <!-- Header: progress + timer -->
+    <div id="exercise-header">
+      <div id="match-counter" class="header-stat"></div>
+      <div id="timer" class="header-stat">⏱ 0:00</div>
+    </div>
+
+    <!-- Progress bar -->
+    <div id="progress-bar-wrap">
+      <div id="progress-bar"></div>
+    </div>
+
+    <!-- Selected word indicator -->
+    <div id="selected-indicator" class="selected-indicator hidden"></div>
+
+    <!-- Two-column matching grid -->
+    <div id="matching-grid" class="matching-grid">
+      <div id="col-left" class="match-col"></div>
+      <div id="col-right" class="match-col"></div>
+    </div>
+  </div>
+
+  <!-- Results screen -->
+  <div id="screen-results" class="screen">
+    <div class="results-content">
+      <div class="results-title" id="results-title"></div>
+      <div class="results-time" id="results-time"></div>
+      <div class="results-breakdown" id="results-breakdown"></div>
+    </div>
+  </div>
+
+  <!-- App modules -->
+  <script src="js/decoder.js"></script>
+  <script src="js/matching.js"></script>
+  <script src="js/results.js"></script>
+  <script src="js/app.js"></script>
+
+</body>
+</html>

--- a/mini-apps/matching/js/app.js
+++ b/mini-apps/matching/js/app.js
@@ -1,0 +1,131 @@
+/**
+ * app.js
+ * Main entry point for the Word Matching Mini App.
+ *
+ * Flow:
+ *   1. Init Telegram WebApp (or warn if running in browser)
+ *   2. Show loading screen
+ *   3. Parse URL params: `words` (required) and `dir` (optional, default 'forward')
+ *   4. Decode `words` payload with decodeWords()
+ *   5. Start matching game via initMatching()
+ *   6. On completion, show results via showMatchingResults()
+ */
+
+(function () {
+  'use strict';
+
+  // ── Telegram WebApp bootstrap ────────────────────────────────────────
+  var tg = window.Telegram && window.Telegram.WebApp;
+
+  if (tg) {
+    tg.ready();
+    tg.expand();
+
+    applyTheme(tg.themeParams);
+
+    tg.onEvent('themeChanged', function () {
+      applyTheme(tg.themeParams);
+    });
+  } else {
+    showBrowserWarning();
+  }
+
+  // ── DOM refs ──────────────────────────────────────────────────────────
+  var screenLoading  = document.getElementById('screen-loading');
+  var screenExercise = document.getElementById('screen-exercise');
+
+  // ── Parse URL parameters ──────────────────────────────────────────────
+  var params      = new URLSearchParams(window.location.search);
+  var wordsParam  = params.get('words');
+  var dirParam    = params.get('dir') || 'forward';
+
+  var direction = (dirParam === 'reverse') ? 'reverse' : 'forward';
+
+  // ── Guard: missing `words` param ──────────────────────────────────────
+  if (!wordsParam) {
+    showError('Данные упражнения не найдены');
+    return;
+  }
+
+  // ── Decode payload ────────────────────────────────────────────────────
+  var words;
+  try {
+    words = decodeWords(wordsParam);
+  } catch (e) {
+    console.error('Decode error:', e);
+    showError('Ошибка декодирования данных');
+    return;
+  }
+
+  // ── Guard: empty word list ────────────────────────────────────────────
+  if (!Array.isArray(words) || words.length === 0) {
+    showError('Нет слов для изучения');
+    return;
+  }
+
+  // ── Start exercise ────────────────────────────────────────────────────
+  screenLoading.classList.remove('screen-active');
+  screenExercise.classList.add('screen-active');
+
+  initMatching(words, direction, function (results, totalMs) {
+    showMatchingResults(results, totalMs);
+  });
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  /**
+   * Apply Telegram theme params as CSS variables on :root.
+   * @param {Object} themeParams - Telegram.WebApp.themeParams
+   */
+  function applyTheme(themeParams) {
+    if (!themeParams) return;
+    var map = {
+      bg_color:            '--tg-theme-bg-color',
+      text_color:          '--tg-theme-text-color',
+      hint_color:          '--tg-theme-hint-color',
+      link_color:          '--tg-theme-link-color',
+      button_color:        '--tg-theme-button-color',
+      button_text_color:   '--tg-theme-button-text-color',
+      secondary_bg_color:  '--tg-theme-secondary-bg-color',
+    };
+    Object.keys(map).forEach(function (key) {
+      if (themeParams[key]) {
+        document.documentElement.style.setProperty(map[key], themeParams[key]);
+      }
+    });
+  }
+
+  /**
+   * Replace loading screen content with an error message.
+   * @param {string} message
+   */
+  function showError(message) {
+    screenLoading.classList.add('screen-active');
+    screenLoading.innerHTML =
+      '<div class="error-content">' +
+        '<div class="error-icon">⚠️</div>' +
+        '<div class="error-message">' + escapeHtml(message) + '</div>' +
+      '</div>';
+  }
+
+  /**
+   * Show a non-blocking warning banner when running in a browser.
+   */
+  function showBrowserWarning() {
+    var banner = document.createElement('div');
+    banner.className = 'browser-warning';
+    banner.textContent =
+      '⚠️ Приложение открыто вне Telegram. Отправка результатов недоступна.';
+    document.body.prepend(banner);
+  }
+
+  /**
+   * Minimal HTML escaping to prevent XSS in error messages.
+   */
+  function escapeHtml(str) {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+})();

--- a/mini-apps/matching/js/decoder.js
+++ b/mini-apps/matching/js/decoder.js
@@ -1,0 +1,43 @@
+/**
+ * decoder.js
+ * Decodes the `words` URL parameter:
+ *   base64url → binary → gzip decompress → JSON parse
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * Decodes an encoded words payload.
+   *
+   * @param {string} encoded - base64url-encoded, gzip-compressed JSON string
+   * @returns {Array} Array of CompactWordPayload objects
+   * @throws {Error} if decoding or parsing fails
+   */
+  function decodeWords(encoded) {
+    // 1. Restore standard base64 characters and padding
+    let b64 = encoded
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+
+    // Add required '=' padding so length is a multiple of 4
+    while (b64.length % 4 !== 0) {
+      b64 += '=';
+    }
+
+    // 2. Decode base64 → binary string → Uint8Array
+    const binaryString = atob(b64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    // 3. Decompress gzip using pako
+    const decompressed = pako.ungzip(bytes, { to: 'string' });
+
+    // 4. Parse JSON and return
+    return JSON.parse(decompressed);
+  }
+
+  window.decodeWords = decodeWords;
+})();

--- a/mini-apps/matching/js/matching.js
+++ b/mini-apps/matching/js/matching.js
@@ -1,0 +1,331 @@
+/**
+ * matching.js
+ * Core matching game logic.
+ *
+ * Public API:
+ *   initMatching(words, direction, onComplete)
+ *   - words:      Array of CompactWordPayload
+ *   - direction:  'forward' (Greek→Russian) or 'reverse' (Russian→Greek)
+ *   - onComplete: function(results) called when all pairs are matched
+ *
+ * Each result object:
+ *   { word_id, rating, time_ms, direction }
+ *
+ * Rating:
+ *   first attempt correct  → 3 (Good)
+ *   second attempt correct → 1 (Hard)
+ *   3+ attempts correct    → 0 (Again)
+ */
+
+(function () {
+  'use strict';
+
+  // ── DOM refs ──────────────────────────────────────────────────────────
+  const colLeft          = document.getElementById('col-left');
+  const colRight         = document.getElementById('col-right');
+  const matchCounterEl   = document.getElementById('match-counter');
+  const progressBarEl    = document.getElementById('progress-bar');
+  const selectedIndicator = document.getElementById('selected-indicator');
+  const timerEl          = document.getElementById('timer');
+
+  // ── State ─────────────────────────────────────────────────────────────
+  let wordStates    = [];   // Array of { word, leftText, rightText, attempts, matched, startTime }
+  let direction     = 'forward';
+  let onComplete    = null;
+  let selectedIdx   = null; // index of currently selected left-column item
+  let matchedCount  = 0;
+  let totalWords    = 0;
+  let timerInterval = null;
+  let startTime     = null;
+  let initialized   = false;
+
+  // ── Init ──────────────────────────────────────────────────────────────
+  function initMatching(wordList, dir, completeCb) {
+    if (initialized) return;
+    initialized = true;
+
+    direction  = (dir === 'reverse') ? 'reverse' : 'forward';
+    onComplete = completeCb;
+    totalWords = wordList.length;
+    matchedCount = 0;
+    selectedIdx  = null;
+
+    // Build per-word state
+    wordStates = wordList.map(function (w) {
+      var leftText, rightText;
+      if (direction === 'forward') {
+        leftText  = w.a ? (w.a + ' ' + w.w) : w.w;
+        rightText = w.tr;
+      } else {
+        leftText  = w.tr;
+        rightText = w.a ? (w.a + ' ' + w.w) : w.w;
+      }
+      return {
+        word:      w,
+        leftText:  leftText,
+        rightText: rightText,
+        attempts:  0,
+        matched:   false,
+        startTime: null,
+      };
+    });
+
+    // Shuffle right-column order
+    var rightOrder = shuffleIndices(totalWords);
+
+    // Render columns
+    renderColumns(rightOrder);
+
+    // Start timer on first render (not on first tap, for consistency)
+    startTime = Date.now();
+    startTimer();
+
+    // Update header
+    updateCounter();
+  }
+
+  // ── Rendering ─────────────────────────────────────────────────────────
+  function renderColumns(rightOrder) {
+    colLeft.innerHTML  = '';
+    colRight.innerHTML = '';
+
+    wordStates.forEach(function (state, idx) {
+      // Left tile
+      var leftTile = document.createElement('div');
+      leftTile.className = 'match-tile match-tile-left';
+      leftTile.dataset.idx = idx;
+      leftTile.textContent = state.leftText;
+      leftTile.addEventListener('click', function () { onLeftTap(idx); });
+      colLeft.appendChild(leftTile);
+    });
+
+    rightOrder.forEach(function (idx) {
+      var state = wordStates[idx];
+      var rightTile = document.createElement('div');
+      rightTile.className = 'match-tile match-tile-right';
+      rightTile.dataset.idx = idx;
+      rightTile.textContent = state.rightText;
+      rightTile.addEventListener('click', function () { onRightTap(idx); });
+      colRight.appendChild(rightTile);
+    });
+  }
+
+  // ── Tap handlers ──────────────────────────────────────────────────────
+  function onLeftTap(idx) {
+    var state = wordStates[idx];
+    if (state.matched) return;
+
+    if (selectedIdx === idx) {
+      // Toggle off
+      deselectLeft(idx);
+      selectedIdx = null;
+      hideSelectedIndicator();
+      return;
+    }
+
+    // Deselect previous
+    if (selectedIdx !== null) {
+      deselectLeft(selectedIdx);
+    }
+
+    selectedIdx = idx;
+
+    // Start timing this word on first tap
+    if (state.startTime === null) {
+      state.startTime = Date.now();
+    }
+
+    selectLeft(idx);
+    showSelectedIndicator(state.leftText);
+  }
+
+  function onRightTap(idx) {
+    if (selectedIdx === null) return; // nothing selected
+    var state = wordStates[idx];
+    if (state.matched) return;
+
+    var selectedState = wordStates[selectedIdx];
+    if (selectedState.matched) return;
+
+    // Evaluate match: right tile's idx must equal selected left idx
+    if (idx === selectedIdx) {
+      // ✅ Correct match
+      handleCorrectMatch(selectedIdx);
+    } else {
+      // ❌ Wrong match
+      handleWrongMatch(selectedIdx, idx);
+    }
+  }
+
+  // ── Match resolution ──────────────────────────────────────────────────
+  function handleCorrectMatch(idx) {
+    var state = wordStates[idx];
+    state.matched  = true;
+    state.attempts += 1;
+
+    // Calculate time
+    var timeMs = state.startTime ? (Date.now() - state.startTime) : 0;
+
+    // Rating: 1st attempt=3, 2nd=1, 3rd+=0
+    var rating;
+    if (state.attempts === 1)      rating = 3;
+    else if (state.attempts === 2) rating = 1;
+    else                           rating = 0;
+
+    state.result = {
+      word_id:   state.word.id,
+      rating:    rating,
+      time_ms:   timeMs,
+      direction: direction,
+    };
+
+    // Visual feedback: flash green then dim
+    flashTiles(idx, 'correct', function () {
+      dimTiles(idx);
+    });
+
+    matchedCount++;
+    selectedIdx = null;
+    hideSelectedIndicator();
+    updateCounter();
+    updateProgress();
+
+    if (matchedCount === totalWords) {
+      finishGame();
+    }
+  }
+
+  function handleWrongMatch(leftIdx, rightIdx) {
+    var state = wordStates[leftIdx];
+    state.attempts += 1;
+
+    // Flash red on both tiles
+    flashWrongTiles(leftIdx, rightIdx, function () {
+      deselectLeft(leftIdx);
+      selectedIdx = null;
+      hideSelectedIndicator();
+    });
+  }
+
+  // ── Visual helpers ────────────────────────────────────────────────────
+  function getTileByIdx(side, idx) {
+    var col = (side === 'left') ? colLeft : colRight;
+    return col.querySelector('[data-idx="' + idx + '"]');
+  }
+
+  function selectLeft(idx) {
+    var tile = getTileByIdx('left', idx);
+    if (tile) tile.classList.add('selected');
+  }
+
+  function deselectLeft(idx) {
+    var tile = getTileByIdx('left', idx);
+    if (tile) tile.classList.remove('selected');
+  }
+
+  function flashTiles(idx, cls, cb) {
+    var leftTile  = getTileByIdx('left',  idx);
+    var rightTile = getTileByIdx('right', idx);
+    [leftTile, rightTile].forEach(function (t) {
+      if (t) {
+        t.classList.remove('selected');
+        t.classList.add(cls);
+      }
+    });
+    setTimeout(cb, 500);
+  }
+
+  function flashWrongTiles(leftIdx, rightIdx, cb) {
+    var leftTile   = getTileByIdx('left',  leftIdx);
+    var rightTile  = getTileByIdx('right', rightIdx);
+    [leftTile, rightTile].forEach(function (t) {
+      if (t) t.classList.add('wrong');
+    });
+    setTimeout(function () {
+      [leftTile, rightTile].forEach(function (t) {
+        if (t) t.classList.remove('wrong');
+      });
+      cb();
+    }, 500);
+  }
+
+  function dimTiles(idx) {
+    var leftTile  = getTileByIdx('left',  idx);
+    var rightTile = getTileByIdx('right', idx);
+    [leftTile, rightTile].forEach(function (t) {
+      if (t) {
+        t.classList.remove('correct', 'selected');
+        t.classList.add('matched');
+      }
+    });
+  }
+
+  // ── Selected indicator ────────────────────────────────────────────────
+  function showSelectedIndicator(text) {
+    selectedIndicator.textContent = '➤ ' + text;
+    selectedIndicator.classList.remove('hidden');
+  }
+
+  function hideSelectedIndicator() {
+    selectedIndicator.classList.add('hidden');
+    selectedIndicator.textContent = '';
+  }
+
+  // ── Counter & progress ────────────────────────────────────────────────
+  function updateCounter() {
+    matchCounterEl.textContent = matchedCount + ' / ' + totalWords + ' совпадений';
+  }
+
+  function updateProgress() {
+    var pct = totalWords > 0 ? (matchedCount / totalWords) * 100 : 0;
+    progressBarEl.style.width = pct + '%';
+  }
+
+  // ── Timer ─────────────────────────────────────────────────────────────
+  function startTimer() {
+    timerInterval = setInterval(function () {
+      var elapsed = Math.floor((Date.now() - startTime) / 1000);
+      var mins = Math.floor(elapsed / 60);
+      var secs = elapsed % 60;
+      timerEl.textContent = '⏱ ' + mins + ':' + (secs < 10 ? '0' : '') + secs;
+    }, 1000);
+  }
+
+  function stopTimer() {
+    if (timerInterval) {
+      clearInterval(timerInterval);
+      timerInterval = null;
+    }
+  }
+
+  // ── Finish ────────────────────────────────────────────────────────────
+  function finishGame() {
+    stopTimer();
+
+    var totalMs = Date.now() - startTime;
+
+    var results = wordStates.map(function (s) { return s.result; });
+
+    setTimeout(function () {
+      if (typeof onComplete === 'function') {
+        onComplete(results, totalMs);
+      }
+    }, 400);
+  }
+
+  // ── Utilities ─────────────────────────────────────────────────────────
+  function shuffleIndices(n) {
+    var arr = [];
+    for (var i = 0; i < n; i++) arr.push(i);
+    for (var j = arr.length - 1; j > 0; j--) {
+      var k = Math.floor(Math.random() * (j + 1));
+      var tmp = arr[j];
+      arr[j] = arr[k];
+      arr[k] = tmp;
+    }
+    return arr;
+  }
+
+  // ── Export ────────────────────────────────────────────────────────────
+  window.initMatching = initMatching;
+})();

--- a/mini-apps/matching/js/matching.js
+++ b/mini-apps/matching/js/matching.js
@@ -38,6 +38,7 @@
   let timerInterval = null;
   let startTime     = null;
   let initialized   = false;
+  let animating     = false; // guard flag: blocks taps during wrong-match flash
 
   // ── Init ──────────────────────────────────────────────────────────────
   function initMatching(wordList, dir, completeCb) {
@@ -76,9 +77,8 @@
     // Render columns
     renderColumns(rightOrder);
 
-    // Start timer on first render (not on first tap, for consistency)
-    startTime = Date.now();
-    startTimer();
+    // Timer starts on first tap (see onLeftTap) to avoid penalising slow
+    // devices or users who read the words before starting.
 
     // Update header
     updateCounter();
@@ -130,6 +130,12 @@
 
     selectedIdx = idx;
 
+    // Start the global timer on the very first tap
+    if (startTime === null) {
+      startTime = Date.now();
+      startTimer();
+    }
+
     // Start timing this word on first tap
     if (state.startTime === null) {
       state.startTime = Date.now();
@@ -141,6 +147,7 @@
 
   function onRightTap(idx) {
     if (selectedIdx === null) return; // nothing selected
+    if (animating) return;            // block taps during wrong-match flash
     var state = wordStates[idx];
     if (state.matched) return;
 
@@ -199,11 +206,15 @@
     var state = wordStates[leftIdx];
     state.attempts += 1;
 
+    // Set guard to block any further taps during the 500ms flash animation
+    animating = true;
+
     // Flash red on both tiles
     flashWrongTiles(leftIdx, rightIdx, function () {
       deselectLeft(leftIdx);
       selectedIdx = null;
       hideSelectedIndicator();
+      animating = false;
     });
   }
 

--- a/mini-apps/matching/js/results.js
+++ b/mini-apps/matching/js/results.js
@@ -1,0 +1,113 @@
+/**
+ * results.js
+ * Renders the results screen and sends data back to Telegram.
+ *
+ * Public API:
+ *   showResults(results, totalMs)
+ *   - results:  Array of { word_id, rating, time_ms, direction }
+ *   - totalMs:  Total elapsed milliseconds for the whole exercise
+ */
+
+(function () {
+  'use strict';
+
+  var RATING_META = [
+    { rating: 0, emoji: '❌', label: 'Снова'  },
+    { rating: 1, emoji: '⚠️', label: 'Трудно' },
+    { rating: 3, emoji: '⭐', label: 'Хорошо' },
+  ];
+
+  function showResults(results, totalMs) {
+    // ── Switch screens ────────────────────────────────────────────────
+    document.getElementById('screen-exercise').classList.remove('screen-active');
+    var screenResults = document.getElementById('screen-results');
+    screenResults.classList.add('screen-active');
+
+    var totalWords = results.length;
+
+    // ── Title ─────────────────────────────────────────────────────────
+    document.getElementById('results-title').textContent =
+      'Готово! ' + totalWords + ' ' + pluralWords(totalWords);
+
+    // ── Total time ────────────────────────────────────────────────────
+    var totalSec = totalMs > 0 ? (totalMs / 1000).toFixed(1) : '0.0';
+    var mins = Math.floor(totalMs / 60000);
+    var secs = Math.floor((totalMs % 60000) / 1000);
+    var timeStr = mins > 0
+      ? mins + ' мин ' + secs + ' сек'
+      : totalSec + ' сек';
+
+    document.getElementById('results-time').textContent = '⏱ Время: ' + timeStr;
+
+    // ── Breakdown ─────────────────────────────────────────────────────
+    var counts = { 0: 0, 1: 0, 3: 0 };
+
+    results.forEach(function (r) {
+      if (counts[r.rating] !== undefined) counts[r.rating]++;
+    });
+
+    var breakdownEl = document.getElementById('results-breakdown');
+    breakdownEl.innerHTML = '';
+
+    RATING_META.forEach(function (meta) {
+      var row = document.createElement('div');
+      row.className = 'results-row';
+
+      var labelWrap = document.createElement('div');
+      labelWrap.className = 'results-row-label';
+      labelWrap.textContent = meta.emoji + '  ' + meta.label;
+
+      var countEl = document.createElement('div');
+      countEl.className = 'results-row-count';
+      countEl.textContent = counts[meta.rating];
+
+      row.appendChild(labelWrap);
+      row.appendChild(countEl);
+      breakdownEl.appendChild(row);
+    });
+
+    // ── Telegram MainButton ───────────────────────────────────────────
+    var tg = window.Telegram && window.Telegram.WebApp;
+
+    if (tg) {
+      tg.MainButton.setText('Отправить результаты');
+      tg.MainButton.show();
+      var handler = function () {
+        try {
+          tg.sendData(JSON.stringify({
+            type: 'exercise_results',
+            results: results,
+          }));
+        } catch (e) {
+          console.error('sendData failed:', e);
+          var errEl = document.createElement('div');
+          errEl.style.cssText =
+            'color:#ff4444;font-size:0.85rem;text-align:center;margin-top:8px;';
+          errEl.textContent = 'Ошибка отправки. Попробуйте снова.';
+          document.querySelector('.results-content').appendChild(errEl);
+        }
+      };
+      tg.MainButton.offClick(handler);
+      tg.MainButton.onClick(handler);
+    } else {
+      // Browser mode — log to console
+      console.info('[matching] sendData payload:', JSON.stringify({
+        type: 'exercise_results',
+        results: results,
+      }));
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+  function pluralWords(n) {
+    var mod10  = n % 10;
+    var mod100 = n % 100;
+    if (mod10 === 1 && mod100 !== 11)              return 'слово';
+    if (mod10 >= 2 && mod10 <= 4 &&
+        (mod100 < 10 || mod100 >= 20))             return 'слова';
+    return 'слов';
+  }
+
+  // ── Export ────────────────────────────────────────────────────────────
+  window.showMatchingResults = showResults;
+})();

--- a/mini-apps/matching/js/results.js
+++ b/mini-apps/matching/js/results.js
@@ -3,7 +3,7 @@
  * Renders the results screen and sends data back to Telegram.
  *
  * Public API:
- *   showResults(results, totalMs)
+ *   showMatchingResults(results, totalMs)
  *   - results:  Array of { word_id, rating, time_ms, direction }
  *   - totalMs:  Total elapsed milliseconds for the whole exercise
  */

--- a/src/assistant/extensions/language_learning/tools/_encoding.py
+++ b/src/assistant/extensions/language_learning/tools/_encoding.py
@@ -1,0 +1,20 @@
+"""
+Shared encoding utilities for language-learning exercise tools.
+"""
+
+import base64
+import gzip
+import json
+from typing import Any
+
+from assistant.extensions.language_learning.models import CompactWordPayload
+
+
+def encode_words(words: list[Any]) -> str:
+    """Encode words as CompactWordPayload list → JSON → gzip → base64url."""
+    payloads = [
+        CompactWordPayload.from_entry(w).model_dump(by_alias=True, exclude_none=True) for w in words
+    ]
+    json_bytes = json.dumps(payloads, ensure_ascii=False).encode("utf-8")
+    compressed = gzip.compress(json_bytes, compresslevel=9)
+    return base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")

--- a/src/assistant/extensions/language_learning/tools/start_exercise.py
+++ b/src/assistant/extensions/language_learning/tools/start_exercise.py
@@ -5,9 +5,6 @@ Start exercise tool for the language learning agent.
 Selects due words, encodes them as CompactWordPayload, and builds a WebApp URL.
 """
 
-import base64
-import gzip
-import json
 import os
 from typing import Any
 
@@ -17,25 +14,15 @@ from pydantic_ai import RunContext
 from assistant.agent.tools.deps import TurnDeps
 from assistant.extensions.language_learning.models import (
     CardDirection,
-    CompactWordPayload,
     LearningStatus,
 )
+from assistant.extensions.language_learning.tools._encoding import encode_words
 
 logger = structlog.get_logger(__name__)
 
 _DEFAULT_LIMIT = 20
 _MAX_LIMIT = 30
 _WEBAPP_URL_ENV = "VOCABULARY_WEBAPP_URL"
-
-
-def _encode_words(words: list[Any]) -> str:
-    """Encode words as CompactWordPayload list → JSON → gzip → base64url."""
-    payloads = [
-        CompactWordPayload.from_entry(w).model_dump(by_alias=True, exclude_none=True) for w in words
-    ]
-    json_bytes = json.dumps(payloads, ensure_ascii=False).encode("utf-8")
-    compressed = gzip.compress(json_bytes, compresslevel=9)
-    return base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")
 
 
 async def start_exercise(
@@ -105,7 +92,7 @@ async def start_exercise(
 
     # Encode words
     try:
-        encoded = _encode_words(selected)
+        encoded = encode_words(selected)
     except Exception as exc:
         logger.warning("ext.language_learning.start_exercise", encode_error=str(exc))
         return {"status": "error", "reason": f"Failed to encode words: {exc}"}

--- a/src/assistant/extensions/language_learning/tools/start_matching_exercise.py
+++ b/src/assistant/extensions/language_learning/tools/start_matching_exercise.py
@@ -6,9 +6,6 @@ Selects a small set of due words, encodes them as CompactWordPayload, and builds
 a WebApp URL pointing to the matching mini-app.
 """
 
-import base64
-import gzip
-import json
 import os
 from typing import Any
 
@@ -18,9 +15,9 @@ from pydantic_ai import RunContext
 from assistant.agent.tools.deps import TurnDeps
 from assistant.extensions.language_learning.models import (
     CardDirection,
-    CompactWordPayload,
     LearningStatus,
 )
+from assistant.extensions.language_learning.tools._encoding import encode_words
 
 logger = structlog.get_logger(__name__)
 
@@ -28,16 +25,6 @@ logger = structlog.get_logger(__name__)
 _DEFAULT_LIMIT = 8
 _MAX_LIMIT = 10
 _WEBAPP_URL_ENV = "MATCHING_WEBAPP_URL"
-
-
-def _encode_words(words: list[Any]) -> str:
-    """Encode words as CompactWordPayload list → JSON → gzip → base64url."""
-    payloads = [
-        CompactWordPayload.from_entry(w).model_dump(by_alias=True, exclude_none=True) for w in words
-    ]
-    json_bytes = json.dumps(payloads, ensure_ascii=False).encode("utf-8")
-    compressed = gzip.compress(json_bytes, compresslevel=9)
-    return base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")
 
 
 async def start_matching_exercise(
@@ -75,6 +62,7 @@ async def start_matching_exercise(
             "reason": f"Invalid direction '{direction}'. Use 'forward' or 'reverse'.",
         }
 
+    # Minimum of 2: a single-pair matching game is nonsensical
     bounded_limit = max(2, min(limit, _MAX_LIMIT))
 
     logger.info(
@@ -110,7 +98,7 @@ async def start_matching_exercise(
 
     # Encode words
     try:
-        encoded = _encode_words(selected)
+        encoded = encode_words(selected)
     except Exception as exc:
         logger.warning("ext.language_learning.start_matching_exercise", encode_error=str(exc))
         return {"status": "error", "reason": f"Failed to encode words: {exc}"}

--- a/src/assistant/extensions/language_learning/tools/start_matching_exercise.py
+++ b/src/assistant/extensions/language_learning/tools/start_matching_exercise.py
@@ -1,0 +1,174 @@
+"""
+Component ID: CMP_EXT_LANGUAGE_LEARNING
+
+Start matching exercise tool for the language learning agent.
+Selects a small set of due words, encodes them as CompactWordPayload, and builds
+a WebApp URL pointing to the matching mini-app.
+"""
+
+import base64
+import gzip
+import json
+import os
+from typing import Any
+
+import structlog
+from pydantic_ai import RunContext
+
+from assistant.agent.tools.deps import TurnDeps
+from assistant.extensions.language_learning.models import (
+    CardDirection,
+    CompactWordPayload,
+    LearningStatus,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Matching works best with fewer items on screen at once
+_DEFAULT_LIMIT = 8
+_MAX_LIMIT = 10
+_WEBAPP_URL_ENV = "MATCHING_WEBAPP_URL"
+
+
+def _encode_words(words: list[Any]) -> str:
+    """Encode words as CompactWordPayload list → JSON → gzip → base64url."""
+    payloads = [
+        CompactWordPayload.from_entry(w).model_dump(by_alias=True, exclude_none=True) for w in words
+    ]
+    json_bytes = json.dumps(payloads, ensure_ascii=False).encode("utf-8")
+    compressed = gzip.compress(json_bytes, compresslevel=9)
+    return base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")
+
+
+async def start_matching_exercise(
+    ctx: RunContext[TurnDeps],
+    direction: str = "forward",
+    limit: int = _DEFAULT_LIMIT,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Start a word-translation matching exercise. Selects due words and returns an exercise URL.
+
+    Shows Greek words and their Russian translations in two columns; the user taps
+    to match each pair. Works best with 8–10 words so the screen remains readable.
+
+    Selects words by priority: NEW words first, then LEARNING words due per FSRS schedule,
+    then KNOWN words when their FSRS review date is reached. SUSPENDED words
+    are never included.
+
+    Args:
+        direction: Card direction — 'forward' (Greek→Russian) or 'reverse' (Russian→Greek).
+        limit: Maximum number of words to include (max 10, default 8).
+        tags: Optional tag filter to restrict the word pool.
+    """
+    user_id = ctx.deps.user_id
+    store = ctx.deps.vocabulary_store
+    if user_id is None or store is None:
+        logger.warning("ext.language_learning.start_matching_exercise", status="unavailable")
+        return {"status": "unavailable", "reason": "language learning not configured"}
+
+    # Validate direction
+    try:
+        card_direction = CardDirection(direction)
+    except ValueError:
+        return {
+            "status": "rejected_invalid",
+            "reason": f"Invalid direction '{direction}'. Use 'forward' or 'reverse'.",
+        }
+
+    bounded_limit = max(2, min(limit, _MAX_LIMIT))
+
+    logger.info(
+        "ext.language_learning.start_matching_exercise",
+        direction=direction,
+        limit=bounded_limit,
+        tags=tags or [],
+    )
+
+    try:
+        selected = await store.get_due_words(
+            user_id,
+            limit=bounded_limit,
+            tags=tags,
+            direction=card_direction,
+        )
+    except Exception as exc:
+        logger.warning("ext.language_learning.start_matching_exercise", error=str(exc))
+        return {"status": "error", "reason": str(exc)}
+
+    if not selected:
+        logger.info("ext.language_learning.start_matching_exercise", status="no_words_due")
+        return {
+            "status": "no_words_due",
+            "message": "No words due for review right now. Great job keeping up!",
+            "word_count": 0,
+        }
+
+    # Categorize selected words for summary
+    new_count = sum(1 for w in selected if w.learning_status == LearningStatus.NEW)
+    due_count = sum(1 for w in selected if w.learning_status == LearningStatus.LEARNING)
+    refresher_count = sum(1 for w in selected if w.learning_status == LearningStatus.KNOWN)
+
+    # Encode words
+    try:
+        encoded = _encode_words(selected)
+    except Exception as exc:
+        logger.warning("ext.language_learning.start_matching_exercise", encode_error=str(exc))
+        return {"status": "error", "reason": f"Failed to encode words: {exc}"}
+
+    # Build WebApp URL
+    raw_url = os.environ.get(_WEBAPP_URL_ENV)
+    if raw_url is None:
+        logger.warning(
+            "ext.language_learning.start_matching_exercise",
+            status="misconfigured",
+            reason=f"{_WEBAPP_URL_ENV} environment variable is not set",
+        )
+        return {
+            "status": "error",
+            "reason": "Exercise cannot be started: Matching WebApp URL is not configured.",
+        }
+    base_url = raw_url.rstrip("/")
+    webapp_url = f"{base_url}?words={encoded}&dir={direction}"
+
+    # Build summary text
+    breakdown_parts: list[str] = []
+    if due_count:
+        breakdown_parts.append(f"{due_count} due")
+    if new_count:
+        breakdown_parts.append(f"{new_count} new")
+    if refresher_count:
+        breakdown_parts.append(f"{refresher_count} refresher")
+    breakdown_str = " + ".join(breakdown_parts) if breakdown_parts else str(len(selected))
+    message = (
+        f"Matching exercise ready: {len(selected)} word pairs ({breakdown_str}). "
+        "Tap the button to start!"
+    )
+
+    logger.info(
+        "ext.language_learning.start_matching_exercise",
+        status="ready",
+        word_count=len(selected),
+        new_count=new_count,
+        due_count=due_count,
+        refresher_count=refresher_count,
+    )
+    return {
+        "status": "exercise_ready",
+        "webapp_url": webapp_url,
+        "word_count": len(selected),
+        "breakdown": {
+            "due": due_count,
+            "new": new_count,
+            "refresher": refresher_count,
+        },
+        "direction": direction,
+        "message": message,
+        "actions": [
+            {
+                "label": "🔤 Начать сопоставление",
+                "web_app_url": webapp_url,
+                "callback_id": "start_matching_exercise",
+                "callback_data": "",
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary

- **New mini-app** `mini-apps/matching/` — recognition-based vocabulary exercise where users tap to pair Greek words with shuffled Russian translations in a two-column layout
- **New backend tool** `start_matching_exercise` — selects 8–10 due words and builds a matching exercise URL; results processing reuses the existing `process_exercise_results` tool unchanged
- **Config updates** — registers the new tool in `tools.yaml` and `language_learning.yaml`; capability prompt updated to describe both exercise types

## Details

### Mini App (`mini-apps/matching/`)
- Same tech stack as flashcards: Vanilla JS + Telegram WebApp SDK + pako.js
- Same `?words=` URL parameter encoding (gzip + base64url) → `decodeWords()` reused verbatim
- Same `sendData()` payload format: `{"type": "exercise_results", "results": [...]}`
- Rating logic: 1st attempt correct → 3 (Good), 2nd → 1 (Hard), 3rd+ → 0 (Again)
- Supports `dir` param (`forward` = Greek→Russian, `reverse` = Russian→Greek)
- Responsive, mobile-first layout following Telegram theme CSS variables
- Visual feedback: green flash on correct match, red shake on wrong match, matched pairs dim

### Backend (`start_matching_exercise`)
- Mirrors `start_exercise` but caps at 10 words and uses `MATCHING_WEBAPP_URL` env var
- `process_exercise_results` requires **no changes** — payload schema is identical

## Test plan

- [ ] Verify pako decompression works with `?words=` param from backend
- [ ] Tap a Greek word → tile highlights with border
- [ ] Tap same Greek word again → deselects (toggle)
- [ ] Tap Russian translation with no word selected → nothing happens
- [ ] Correct match → green flash, pair dims, counter increments
- [ ] Wrong match → red shake, selection clears, attempts counter increments
- [ ] All pairs matched → results screen appears with correct breakdown (Good/Hard/Again)
- [ ] `sendData()` payload accepted by `process_exercise_results` without schema errors
- [ ] Works in both `forward` and `reverse` directions
- [ ] `MATCHING_WEBAPP_URL` not set → tool returns descriptive error

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)